### PR TITLE
Remove `from` from presentModally

### DIFF
--- a/Demo/Navigation/AppNavigation.swift
+++ b/Demo/Navigation/AppNavigation.swift
@@ -59,6 +59,17 @@ extension ModalTestViewController: Routable {
   var routeIdentifier: RouteElementIdentifier {
     return Screen.modalTest.rawValue
   }
+  
+  func presentModally(modal: RouteElementIdentifier,
+                      animated: Bool,
+                      completion: @escaping RoutingCompletion) -> Bool {
+    if modal == Screen.modalTest.rawValue {
+      let vc = ModalTestViewController(store: self.store)
+      self.present(vc, animated: animated, completion: completion)
+      return true
+    }
+    return false
+  }
 }
 
 // TABBAR
@@ -67,15 +78,12 @@ extension TabBarController: Routable {
     return Screen.tabbar.rawValue
   }
   
-  func presentModally(from: UIViewController,
-                      modal: RouteElementIdentifier,
+  func presentModally(modal: RouteElementIdentifier,
                       animated: Bool,
                       completion: @escaping RoutingCompletion) -> Bool {
     if modal == Screen.modalTest.rawValue {
       let vc = ModalTestViewController(store: self.store)
-      from.present(vc, animated: animated, completion: {
-        completion()
-      })
+      self.present(vc, animated: animated, completion: completion)
       return true
     }
     return false

--- a/Tempura/Navigation/Navigator.swift
+++ b/Tempura/Navigation/Navigator.swift
@@ -27,7 +27,7 @@ public class Navigator {
   }
   
   private func install(identifier: RouteElementIdentifier) {
-    self.rootInstaller?.installRoot(identifier: identifier, completion: { 
+    self.rootInstaller?.installRoot(identifier: identifier, completion: {
       self.window?.makeKeyAndVisible()
     })
   }
@@ -120,15 +120,13 @@ public class Navigator {
         case .presentModally(routeElementToPresentModally: let identifier):
           DispatchQueue.main.async {
             let routables = UIApplication.shared.currentRoutables.reversed()
-            let topViewController = UIApplication.shared.currentViewControllers.last!
             var handled = false
             
             for routable in routables where !handled {
-              handled = routable.presentModally(from: topViewController,
-                                                       modal: identifier,
-                                                       animated: isAnimated,
-                                                       completion: {
-                                                        semaphore.signal()
+              handled = routable.presentModally(modal: identifier,
+                                                animated: isAnimated,
+                                                completion: {
+                                                  semaphore.signal()
               })
             }
             
@@ -147,10 +145,10 @@ public class Navigator {
             
             for routable in routables where !handled {
               handled = routable.dismissModally(identifier: identifier,
-                                                       vcToDismiss: viewControllerToDismiss,
-                                                       animated: isAnimated,
-                                                       completion: {
-                                                        semaphore.signal()
+                                                vcToDismiss: viewControllerToDismiss,
+                                                animated: isAnimated,
+                                                completion: {
+                                                  semaphore.signal()
               })
             }
             
@@ -203,10 +201,10 @@ public class Navigator {
         routeChanges.append(change)
       }
     }
-    // case 2 we need to PUSH element because we are in a situation like this:
-    // OLD: A
-    // NEW: A -> B -> C
-    // push all the elements in the new route that were not in the old route
+      // case 2 we need to PUSH element because we are in a situation like this:
+      // OLD: A
+      // NEW: A -> B -> C
+      // push all the elements in the new route that were not in the old route
     else if commonRouteIndex == old.count - 1 {
       for pushIndex in (commonRouteIndex + 1)..<new.count {
         let elementToPush = new[pushIndex]
@@ -214,10 +212,10 @@ public class Navigator {
         routeChanges.append(change)
       }
     }
-    // case 3 we need to CHANGE elements because we are in a situation like this:
-    // OLD: A -> B -> C
-    // NEW: A -> D -> E
-    // change B with D
+      // case 3 we need to CHANGE elements because we are in a situation like this:
+      // OLD: A -> B -> C
+      // NEW: A -> D -> E
+      // change B with D
     else {
       let change = RouteChange.change(currentRouteElementIdentifier: old[commonRouteIndex], from: old[commonRouteIndex + 1], to: new[commonRouteIndex + 1])
       routeChanges.append(change)

--- a/Tempura/Navigation/Routable.swift
+++ b/Tempura/Navigation/Routable.swift
@@ -29,13 +29,11 @@ public protocol Routable {
   
   /// handle a modal view controller
   /// in order to avoid code repetition you should handle modals at the lowest possible level of the routing tree
-  /// from: the UIViewController to use to present the modal view controller
   /// modal: the identifier of the view controller to present
   /// animated: specify if the presentation should be animated
   /// completion: this completion handler MUST be called when the presentation is complete
   /// return true if self is handling the presentation of the modal
-  func presentModally(from: UIViewController,
-                   modal: RouteElementIdentifier,
+  func presentModally(modal: RouteElementIdentifier,
                    animated: Bool,
                    completion: @escaping RoutingCompletion) -> Bool
   
@@ -66,8 +64,7 @@ public extension Routable {
     fatalError("This Routable element cannot change the navigation, the implementation of \(#function) is missing")
   }
   
-  public func presentModally(from: UIViewController,
-                             modal: RouteElementIdentifier,
+  public func presentModally(modal: RouteElementIdentifier,
                              animated: Bool,
                              completion: @escaping RoutingCompletion) -> Bool {
     return false


### PR DESCRIPTION
I believe we should remove `from` from the following method.

```public func presentModally(from: UIViewController, 
modal: RouteElementIdentifier,	 
animated: Bool,
completion: @escaping RoutingCompletion) -> Bool 
```

The `from` parameter contains the top most VC in the stack of VC currently shown to the user, and the documentation suggests to use this VC to present the modal VC. This is a bad idea because it leads to not deterministic presenter/presented relationship and so not deterministic navigation behaviour.

 Example: A presents B modally and it dismisses it after a 3 seconds timer is fired (a countdown). In the meanwhile a push notification makes so that a modal VC C is presented. If we use B to present C, when the timer is fired C is dismissed unintentionally. 
