### PR TITLE
Remove init() requirement from ViewModel

### DIFF
--- a/Demo/UI/AnimationTest/AnimationTestView.swift
+++ b/Demo/UI/AnimationTest/AnimationTestView.swift
@@ -13,12 +13,6 @@ import PinLayout
 class AnimationTestView: UIView, ViewControllerModellableView {
   
   typealias VM = AnimationTestViewModel
-
-  var model: AnimationTestViewModel = AnimationTestViewModel() {
-    didSet {
-      self.update(oldModel: oldValue)
-    }
-  }
   
   // MARK: - SUBVIEWS
   lazy var button: UIButton = {
@@ -55,7 +49,7 @@ class AnimationTestView: UIView, ViewControllerModellableView {
   }
   
   // MARK: - UPDATE
-  func update(oldModel: AnimationTestViewModel) {
+  func update(oldModel: AnimationTestViewModel?) {
     self.expanded = self.model.expanded
   }
   

--- a/Demo/UI/DependenciesTest/DependenciesTestView.swift
+++ b/Demo/UI/DependenciesTest/DependenciesTestView.swift
@@ -45,7 +45,7 @@ class DependenciesTestView: UIView, ViewControllerModellableView {
   }
   
   // MARK: - UPDATE
-  func update(oldModel: DependenciesTestViewModel) {
+  func update(oldModel: DependenciesTestViewModel?) {
   }
   
   // MARK: - INTERACTION

--- a/Demo/UI/Home/HomeView.swift
+++ b/Demo/UI/Home/HomeView.swift
@@ -64,13 +64,12 @@ class HomeView: UIView, ViewControllerModellableView {
   }
   
   // UPDATE
-  func update(oldModel: HomeViewModel) {
-    let model = self.model
-    self.collectionDelegate.coverStory = model.coverStory
-    self.collectionDelegate.stories = Array(model.stories.values)
-    self.collectionDelegate.newFromCommunityStories = model.newStoriesFromCommunity
-    self.collectionDelegate.readingStories = model.pendingStories
-    self.collectionDelegate.trendingStories = model.trendingStories
+  func update(oldModel: HomeViewModel?) {
+    self.collectionDelegate.coverStory = self.model.coverStory
+    self.collectionDelegate.stories = Array(self.model.stories.values)
+    self.collectionDelegate.newFromCommunityStories = self.model.newStoriesFromCommunity
+    self.collectionDelegate.readingStories = self.model.pendingStories
+    self.collectionDelegate.trendingStories = self.model.trendingStories
 
     self.collectionView.reloadData()
   }

--- a/Demo/UI/LocalStateTest/LocalStateTestView.swift
+++ b/Demo/UI/LocalStateTest/LocalStateTestView.swift
@@ -71,7 +71,7 @@ class LocalStateTestView: UIView, ViewControllerModellableView {
   }
   
   // MARK: - UPDATE
-  func update(oldModel: LocalStateTestViewModel) {
+  func update(oldModel: LocalStateTestViewModel?) {
     self.globalCounterLabel.text = self.model.globalCounterString
     self.localCounterLabel.text = self.model.localCounterString
   }

--- a/Demo/UI/Main/MainView.swift
+++ b/Demo/UI/Main/MainView.swift
@@ -53,8 +53,8 @@ class MainView: UIView, ViewControllerModellableView {
   }
   
   // MARK: - Update
-  func update(oldModel: MainViewModel) {
-    self.counter.text = model.count
+  func update(oldModel: MainViewModel?) {
+    self.counter.text = self.model.count
   }
   
   // MARK: - Interaction callbacks

--- a/Demo/UI/ModalTest/ModalTestView.swift
+++ b/Demo/UI/ModalTest/ModalTestView.swift
@@ -55,7 +55,7 @@ class ModalTestView: UIView, ViewControllerModellableView {
   }
   
   // MARK: - UPDATE
-  func update(oldModel: ModalTestViewModel) {}
+  func update(oldModel: ModalTestViewModel?) {}
   
   // MARK: - INTERACTION
   var closeButtonDidTap: Interaction?

--- a/Demo/UI/StoryChat/StoryChatView.swift
+++ b/Demo/UI/StoryChat/StoryChatView.swift
@@ -22,7 +22,7 @@ class StoryChatView: UIView, ViewControllerModellableView {
   }
   
   // UPDATE
-  func update(oldModel: StoryChatViewModel) {
+  func update(oldModel: StoryChatViewModel?) {
   }
   
   // INTERACTION

--- a/Demo/UI/StoryCover/StoryCoverView.swift
+++ b/Demo/UI/StoryCover/StoryCoverView.swift
@@ -88,7 +88,7 @@ class StoryCoverView: UIView, ViewControllerModellableView {
   }
   
   // MARK: - UPDATE
-  func update(oldModel: StoryCoverViewModel) {
+  func update(oldModel: StoryCoverViewModel?) {
     self.backgroundImage.image = self.model.cover
     self.title.attributedText = self.attributedStringForTitle(title: self.model.title)
     self.subtitle.attributedText = self.attributedStringForSubtitleComponents(components: self.model.subtitleComponents)

--- a/Tempura/Core/ModellableView.swift
+++ b/Tempura/Core/ModellableView.swift
@@ -32,10 +32,10 @@ public protocol ModellableView: View, LiveReloadableView {
   associatedtype VM: ViewModel
   
   /// the ViewModel of the View. Once changed, the `update(oldModel: VM)` will be called
-  var model: VM { get set }
+  var model: VM! { get set }
   
   /// the ViewModel is changed, update the View using the `oldModel` and the new `self.model`
-  func update(oldModel: VM)
+  func update(oldModel: VM?)
   
   /**
    This method is invoked before `update` and `layout` are invoked
@@ -54,14 +54,14 @@ public protocol ModellableView: View, LiveReloadableView {
    This method is never invoked in production runs as well as other live
    reload methods.
    */
-  func liveReloadOldModel() -> VM
+  func liveReloadOldModel() -> VM?
 }
 
 /// implementation detail, wrapper of the model to work with the associatedObject mechanism
 private final class ModelWrapper<VM: ViewModel> {
-  var model: VM
+  var model: VM?
   
-  init(model: VM) {
+  init(model: VM?) {
     self.model = model
   }
 }
@@ -74,10 +74,10 @@ public extension ModellableView {
       if let modelWrapper = objc_getAssociatedObject(self, &modelWrapperKey) as? ModelWrapper<VM> {
         return modelWrapper
       }
-      
-      let newWrapper = ModelWrapper(model: VM())
+      let newWrapper = ModelWrapper<VM>(model: nil)
       self.modelWrapper = newWrapper
       return newWrapper
+
     }
     
     set {
@@ -90,7 +90,7 @@ public extension ModellableView {
     }
   }
   
-  public var model: VM {
+  public var model: VM! {
     get {
       return self.modelWrapper.model
     }
@@ -98,6 +98,7 @@ public extension ModellableView {
     set {
       let oldValue = self.model
       self.modelWrapper.model = newValue
+
       self.update(oldModel: oldValue)
     }
   }
@@ -121,7 +122,7 @@ public extension ModellableView {
   }
   
   /// The default implementation return the current model
-  func liveReloadOldModel() -> VM {
+  func liveReloadOldModel() -> VM? {
     return self.model
   }
   

--- a/Tempura/Core/ViewController.swift
+++ b/Tempura/Core/ViewController.swift
@@ -53,7 +53,7 @@ open class ViewController<V: ViewControllerModellableView, S: State>: UIViewCont
   public var shouldDisconnectOnViewWillDisappear = true
   
   /// used to have the last viewModel available if we want to update it for local state changes
-  public var viewModel: V.VM = V.VM() {
+  public var viewModel: V.VM! {
     didSet {
       // the viewModel is changed, update the View
       self.rootView.model = viewModel

--- a/Tempura/Core/ViewControllerWithLocalState.swift
+++ b/Tempura/Core/ViewControllerWithLocalState.swift
@@ -68,7 +68,7 @@ open class ViewControllerWithLocalState<V: ViewControllerModellableView, S: Stat
   private var unsubscribe: StoreUnsubscribe?
   
   /// used to have the last viewModel available if we want to update it for local state changes
-  public var viewModel: V.VM = V.VM() {
+  public var viewModel: V.VM! {
     didSet {
       // the viewModel is changed, update the View
       self.rootView.model = viewModel

--- a/Tempura/Core/ViewModel.swift
+++ b/Tempura/Core/ViewModel.swift
@@ -10,7 +10,4 @@ import Foundation
 import Katana
 
 public protocol ViewModel {
-  init()
-  
-  
 }


### PR DESCRIPTION
Changes: 
- the `ViewModel` protocol does not require the empty `init()`, this means that you are no longer forced to provide defaults for all the values (even if it's strongly suggested)

- `ViewController` is not creating an empty instance of the `ViewModel`, this means that the first time your `update(oldModel: VM?)` method will be called, the oldModel will actually be `nil` giving you the ability to distinguish the first update cycle (for instance to avoid animations)

- the old `model: VM` var in the `ModellableView` is now a `model: VM!` so that nothing changes from the usage perspective. In the typical use case (that is when you ask for the model inside the update method) the `model` is always instantiated so it's safe to use the forced unwrapped.
If you need to access the `model` in an unsafe context you can still prepend your code with a `guard let model = self.model else { return }` to be safe.

no API changes are needed at the app level (*) (edit: actually the change is breaking as the update method signature is changed)