### PR TITLE
Prevent eager load of ViewController's rootView

### DIFF
--- a/Tempura/Core/ViewController.swift
+++ b/Tempura/Core/ViewController.swift
@@ -51,7 +51,8 @@ open class ViewController<V: ViewControllerModellableView & UIView>: UIViewContr
       self.willUpdate(new: newValue)
     }
     didSet {
-      // the viewModel is changed, update the View
+      // the viewModel is changed: update the View (if loaded)
+      guard self.isViewLoaded else { return }
       self.rootView.model = viewModel
       self.didUpdate(old: oldValue)
     }
@@ -170,7 +171,9 @@ open class ViewController<V: ViewControllerModellableView & UIView>: UIViewContr
   
   /// call the setupInteraction method when the ViewController is loaded
   open override func viewDidLoad() {
+    self.rootView.model = self.viewModel
     super.viewDidLoad()
+    self.didUpdate(old: nil)
     self.setupInteraction()
   }
   


### PR DESCRIPTION
Guard that a view controller's view is loaded before setting the viewModel to the rootView in order to prevent the view from loading before it's actually needed.

This restores the expected behavior of stock UIViewControllers, and could have positive performance implications (e.g. when initializing a TabBarController with several 'heavy' children).