### PR TITLE
Fix landscape issue with uitest folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Master
 
+* Make so that ui tests folders are consistent when landscape is involved. A screenshot from a portrait iPhone 5 will be in the same directory as a landscape iPhone 5 screenshot
+
 ## 1.8.1
 
 - fixed LocalURLProtocol implementation to support DownloadTask and similar approaches

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-## Master
+## 1.8.2
 
-* Make so that ui tests folders are consistent when landscape is involved. A screenshot from a portrait iPhone 5 will be in the same directory as a landscape iPhone 5 screenshot
+* UI tests folders are consistent when landscape screenshots are involved. A screenshot from an iPhone X in portrait will be in the same directory of a screenshot of an iPhone X in landscape
 
 ## 1.8.1
 

--- a/Tempura/UITests/UITests.swift
+++ b/Tempura/UITests/UITests.swift
@@ -237,7 +237,10 @@ public enum UITests {
   
   private static func saveImage(_ image: UIImage, description: String) {
     guard var dirPath = Bundle.main.infoDictionary?["UI_TEST_DIR"] as? String else { fatalError("UI_TEST_DIR not defined in your info.plist") }
-    let screenSizeDescription: String = "\(UIScreen.main.bounds.size.description)"
+    
+    let screenSize = UIScreen.main.bounds.size
+    let screenSizeDescription: String = "\(min(screenSize.width, screenSize.height))x\(max(screenSize.width, screenSize.height)))"
+    
     dirPath = dirPath.appending("/\(screenSizeDescription)/")
     
     let fileManager = FileManager.default


### PR DESCRIPTION
Landscape and portrait ui tests were located in different folders, which doesn't make much sense as you want to look at a certain device screenshots. This PR fixes it