### PR TITLE
Feature/localized screenshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ Pods/
 Carthage/
 /build
 /Demo/UITests/
+TempuraHelpers.xcscheme

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.8.3
+
+* UI tests folder structure uses the locale of the app to support multiple language UITests
+
 ## 1.8.2
 
 * UI tests folders are consistent when landscape screenshots are involved. A screenshot from an iPhone X in portrait will be in the same directory of a screenshot of an iPhone X in landscape

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,10 +1,10 @@
 PODS:
   - DeepDiff (1.2.0)
   - Katana (1.0.0)
-  - Nimble (7.1.0)
-  - PinLayout (1.6.0)
-  - Quick (1.2.0)
-  - Tempura (1.8.0):
+  - Nimble (7.1.1)
+  - PinLayout (1.7.4)
+  - Quick (1.3.0)
+  - Tempura (1.8.2):
     - Katana (< 1.1, >= 1.0)
 
 DEPENDENCIES:
@@ -16,7 +16,7 @@ DEPENDENCIES:
   - Tempura (from `.`)
 
 SPEC REPOS:
-  https://github.com/CocoaPods/Specs.git:
+  https://github.com/cocoapods/specs.git:
     - DeepDiff
     - Katana
     - Nimble
@@ -30,11 +30,11 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   DeepDiff: 0ee83ac6942d441f677c22e981548c6e0937f2b6
   Katana: f45caad244d2f375d41068d94a7758b576940fd2
-  Nimble: 9c6651c3021af6de54c3ed90a4a0a87d548f7359
-  PinLayout: a2bbe9057d49a1e326b13dc4fe8c14751f8c8844
-  Quick: 58d203b1c5e27fff7229c4c1ae445ad7069a7a08
+  Nimble: 391f07782af4b37914f9bd7b2ffbb952731b8202
+  PinLayout: 7903960df1061eeebd393690286df73e002d9b20
+  Quick: 03278013f71aa05fe9ecabc94fbcc6835f1ee76f
   Tempura: 537246abd73aec81ded8b921ff344d507a8673a7
 
 PODFILE CHECKSUM: db457736fb5652b9d426af539f9e0406e65e4f05
 
-COCOAPODS: 1.5.0
+COCOAPODS: 1.5.3

--- a/README.md
+++ b/README.md
@@ -195,6 +195,22 @@ xcodebuild \
 
 Tests will run in parallel on all the devices. If you want to change the behaviour, refer to the `xcodebuild` documentation
 
+If you want to test a specific language in the ui test, you can replace the `test` command with the `-testLanguage <iso code639-1>`.
+The app will be launched in that language and the UITests will be executed with that locale. An example:
+
+```bash
+xcodebuild \
+  -workspace <project>.xcworkspace \
+  -scheme "<target name>" \
+  -destination name="iPhone 5s" \
+  -destination name="iPhone 6 Plus" \
+  -destination name="iPhone 6" \
+  -destination name="iPhone X" \
+  -destination name="iPad Pro (12.9 inch)" \
+  -testLanguage it
+```
+
+
 #### Remote Resources
 
 It happens often that the UI needs to show remote content (that is, remote images, remote videos, ...). While executing UITests this could be a problem as:

--- a/Tempura.xcodeproj/project.pbxproj
+++ b/Tempura.xcodeproj/project.pbxproj
@@ -6,593 +6,592 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		01F10E973C03D7C684CAABA2 /* Pods_TempuraTesting.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FBF527EEA9D82E7D88E04C9E /* Pods_TempuraTesting.framework */; };
-		05080C1534BF13CAB2D30021 /* Pods_Tempura_Demo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A6DA550B8A8326AB98C04AA1 /* Pods_Tempura_Demo.framework */; };
-		08F25C6B8161D0978DDD56C4 /* AddItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F09881D30E865B17BCCC778F /* AddItemView.swift */; };
-		0BC07B9E89823ACA783B29B5 /* NavigationDSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57CC57E8577FB471F766CBED /* NavigationDSL.swift */; };
-		150D2AB10915E6563FECD62C /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 01E2F772ED2425A3C51BA35B /* Foundation.framework */; };
-		1B40901ADAA3CF591F31D0A2 /* String+Random.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36FF4555ABB519D77C62D3A4 /* String+Random.swift */; };
-		1DCBAFA218B5A12DBCA087C2 /* ModellableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E6BBCD79E966D1F43FF6A2A /* ModellableView.swift */; };
-		1E61DD2B71E058CFA3534114 /* DataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4BB637B188E7E5ACA1EB81F /* DataSource.swift */; };
-		24ADA1B4A3967EF79994CB2E /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 482630945BAF553C141B76D1 /* UIKit.framework */; };
-		251F7D394654B7829D2B9AA8 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 482630945BAF553C141B76D1 /* UIKit.framework */; };
-		289620B3E828CDB63606753A /* ViewControllerWithLocalState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88E46B566D70E08C3E60ADE5 /* ViewControllerWithLocalState.swift */; };
-		295C6ED37C94DB9D45C92D3A /* ListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D1314E6A2A2F4285B98FC2 /* ListViewController.swift */; };
-		30B843FEDD9DCBEAF0E909EB /* DependenciesContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E066F66649DC2B77B487DEBC /* DependenciesContainer.swift */; };
-		3178E1307B8714BDC91E86DF /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 01E2F772ED2425A3C51BA35B /* Foundation.framework */; };
-		32AB0F183C1ADC7621F1DAD9 /* Tempura.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1C67EB1DECD1DC32B8FBC98F /* Tempura.framework */; };
-		33CD89A43B08C0F440EF41F8 /* NavigationUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 631F5874534FFC3732CBC19D /* NavigationUtilities.swift */; };
-		35F06C66ECD30B414D0582F3 /* ListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B2642949D2EA50F68450D2F /* ListView.swift */; };
-		3946C9CF0022A7679B5239BD /* TodoCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC2176216F33A18854B82714 /* TodoCell.swift */; };
-		3A709D65BA96CBEE35F0DF2A /* LocalFileURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 268CA34D277FB8EF167F5E2A /* LocalFileURLProtocol.swift */; };
-		3DEC2F7C8EF92B812B4A5ECD /* ViewControllerWithLocalState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D888A7D92B83D5EE00C7877 /* ViewControllerWithLocalState.swift */; };
-		406D49FA794EF688698D8EA3 /* AppNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EE19A3969331B748D2642ED /* AppNavigation.swift */; };
-		412C25513119ADF5DE7624AD /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 482630945BAF553C141B76D1 /* UIKit.framework */; };
-		42222A378B10D633085E3E64 /* ConfigurableCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD0777D7421F68D73BB8132 /* ConfigurableCell.swift */; };
-		44F41A5BB782CA4908E2DC6F /* Pods_Tempura.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B7EAEC5D537BAE8561945346 /* Pods_Tempura.framework */; };
-		5FC4802014383D7846F4FB39 /* ViewControllerModellableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74773A038BE50FDB8C48B29C /* ViewControllerModellableView.swift */; };
-		623CD15F07838DAADF036BE3 /* TextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D782DC558DB2AFC44D3324C /* TextView.swift */; };
-		64BD1A49443C630F6E52FA7D /* Routable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D97907AFB59F527978BA88A /* Routable.swift */; };
-		6648260C83F58CAF6E03802D /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 01E2F772ED2425A3C51BA35B /* Foundation.framework */; };
-		6A8B1A5C8CA4F6EC0DBD99E9 /* UIControl+TargetActionable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63E5CE8DDD9025A97C3BE5F9 /* UIControl+TargetActionable.swift */; };
-		718E36C65915D91064B99B9F /* Pods_DemoTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 587850D7F800CF538EEE2A83 /* Pods_DemoTests.framework */; };
-		725063F64140B577096B12E6 /* RootInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC88326A32EE77E9A36B8DD8 /* RootInstaller.swift */; };
-		7370D3231701EDEC37F700C7 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 482630945BAF553C141B76D1 /* UIKit.framework */; };
-		78FDC854059BAB970749BF4E /* UITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C01B95502FF0868DCED4E267 /* UITests.swift */; };
-		7C59C9EFAA5918705515D3F4 /* Navigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDFDA1ECAD8573D520306050 /* Navigator.swift */; };
-		7DE6B38DB208E665B6091579 /* MainThread.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7368059D2F2383A9C8771B3 /* MainThread.swift */; };
-		7FD8052C66F108B5D6F4BC66 /* ViewModelWithLocalState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8085F32D3577898B62F727C0 /* ViewModelWithLocalState.swift */; };
-		86F882987AEF281D66C45E0B /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 01E2F772ED2425A3C51BA35B /* Foundation.framework */; };
-		91C62C450949534A2F7EA813 /* Media.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7180309A39E4F8186CC96AB5 /* Media.xcassets */; };
-		9202EC82DED66B1E61F70AD4 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D585DFB8C1983F404427C7B /* ViewController.swift */; };
-		9803B7C48C37CBBB082FFFD0 /* AsyncUITest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A60147674CB769C5FB573F1 /* AsyncUITest.swift */; };
-		9A65E04602168AD6F273607C /* Source.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE698AA550F7FA01BC257027 /* Source.swift */; };
-		9B3DF59E91CEC66D72808B13 /* AppActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4D49F37A6EEB01D053F7784 /* AppActions.swift */; };
-		9EEBB05747812057F4E3C282 /* ViewModelWithState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43DB747145736860CDD24B3B /* ViewModelWithState.swift */; };
-		A0B0822B065B0E94ABC3890F /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FD26121728299DA6907967E /* Models.swift */; };
-		B50FD728EB41C32748F05123 /* ArchiveFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC4E45A155B29BE07953C811 /* ArchiveFlowLayout.swift */; };
-		B71246BF4DB68D05BA3625FD /* TodoFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF1CD666FA56629F1DC5D39 /* TodoFlowLayout.swift */; };
-		BFFD821875E2E6A2DF495026 /* AddItemViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E44A8B6B91E848D7C197F88 /* AddItemViewController.swift */; };
-		C5EEE679D8F94F4778F956A2 /* UIView+Blink.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAD88A27255297A902591032 /* UIView+Blink.swift */; };
-		C6D41F258158A8208015290F /* DemoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF865F48BBFF042F297B7F2C /* DemoTests.swift */; };
-		C72884173D9DF1921786A011 /* CollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A11636FCE0CB71011EE787E /* CollectionView.swift */; };
-		CF1B6C43EBF075406B5195AC /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBF0FC91E393CB5C7BB828F9 /* AppState.swift */; };
-		D18D4A5891C020E574162675 /* UIView+snapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 595C2F826BCE63F865944A89 /* UIView+snapshot.swift */; };
-		D8E6F8BBA85F35B1C82C1B5A /* Tempura.h in Headers */ = {isa = PBXBuildFile; fileRef = D854F243A699251C097F3659 /* Tempura.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D91D1615297CFB528CAE190E /* ViewControllerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9545FB7230C045BF66A44D21 /* ViewControllerSpec.swift */; };
-		DBEDC6FB7DB65ABF94664A5A /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 482630945BAF553C141B76D1 /* UIKit.framework */; };
-		DC5898710AC77ABF91A4BEFC /* LocalState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A5948CAEDCE97F17AE86864 /* LocalState.swift */; };
-		E0361285BDD779F39B07A93B /* CGRect+Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A07C54A54D8E027DA00C353 /* CGRect+Utils.swift */; };
-		E2AD5EDE0607E39BDF2D91DD /* Tempura.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1C67EB1DECD1DC32B8FBC98F /* Tempura.framework */; };
-		E3754E56157F83483F7D3099 /* Demo.app in Frameworks */ = {isa = PBXBuildFile; fileRef = B65B063D8BBBD5F462EDC289 /* Demo.app */; };
-		E45D168B17CE1F24987002E9 /* NavigationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD3CCC90CE97F278909BD834 /* NavigationProvider.swift */; };
-		E888F44E4CE4F3E3EF334C12 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 01E2F772ED2425A3C51BA35B /* Foundation.framework */; };
-		E971CFC0889CC9BDAA96754C /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B6B7FC64E60C11B94A2902D /* AppDelegate.swift */; };
-		EA4C61EFB95CDB43A335CA19 /* String+Height.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEED91B30AFC547F5732A274 /* String+Height.swift */; };
-		F56B1FB4432EA880B3BCACB2 /* ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEF91CA7FC7EE66EFFB4EB2E /* ViewModel.swift */; };
-		F72D5F6CEBDC4FC36D80E47E /* View.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA15836F6B3D87BE1FAD771 /* View.swift */; };
-		F7C3D28120279CA681F8064A /* ItemActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F537A90B62D747C9AA7A8E /* ItemActions.swift */; };
-		F828C365D1896266017301E3 /* Pods_TempuraTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 72DDFE41A333A7BF0DC291C9 /* Pods_TempuraTests.framework */; };
-		FA16FA60ACE255F8A17B22FA /* NavigationActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16EFCD7BA9311BA2EF5486BE /* NavigationActions.swift */; };
-		FC88BE45A001668088063460 /* Tempura.h in Headers */ = {isa = PBXBuildFile; fileRef = D854F243A699251C097F3659 /* Tempura.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		00E4A160141422D409F4D08E /* ArchiveFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F41B29DFC62B2985C10B45 /* ArchiveFlowLayout.swift */; };
+		07F766AFC906D61CA38A6759 /* TextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32CBB43468E3367CB492834E /* TextView.swift */; };
+		0958975565897918175D5171 /* AddItemViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 436316A65E092D4E747F4B23 /* AddItemViewController.swift */; };
+		0F83B97AF6431FA074B57C3C /* ModellableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B08F0E49B2120828BF14CBF5 /* ModellableView.swift */; };
+		1D2A3735B4E8E55BE2A27857 /* Source.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F3396E6D30E2168C028BBC7 /* Source.swift */; };
+		2542575AB7E5E10F132A9660 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A068A7E777A32BE636AE96F7 /* Foundation.framework */; };
+		265217387F567F42CD2FDC91 /* DemoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8976A233755FF97E27755795 /* DemoTests.swift */; };
+		29A8CBD8C0B48086F9C63D1C /* Routable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36EE94D33BF3422F158EF1C /* Routable.swift */; };
+		2C4816D452D501745D38E420 /* NavigationUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = A45E0875535580941275E976 /* NavigationUtilities.swift */; };
+		384EF477FC7D61339F8A314A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A068A7E777A32BE636AE96F7 /* Foundation.framework */; };
+		3BA3D2466DE388ABD9A067E6 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2B04E9E3A5DC3C1280EEF96 /* UIKit.framework */; };
+		3CCFA32C7EE09408AD4FC2B2 /* ViewControllerWithLocalState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9B2CE9D5CC2452E7F3F8FE4 /* ViewControllerWithLocalState.swift */; };
+		3DE257E17D92AA9DB6787004 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47E6CF03C58E0FDB7E111C2C /* ViewController.swift */; };
+		44C79E4265260D9F72115CAA /* LocalFileURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7619E7499D0198D451B727E8 /* LocalFileURLProtocol.swift */; };
+		48F91F7160C6E36F0184A368 /* CollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263FE4C84B71DD4E96506B71 /* CollectionView.swift */; };
+		4A6BDEB84E556AAC89445F29 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2B04E9E3A5DC3C1280EEF96 /* UIKit.framework */; };
+		4B8DBA6D00BF78753B58499F /* Tempura.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F1184881A6C5AA7E0CBA1142 /* Tempura.framework */; };
+		4DBA4F1D52371F75AC3A3453 /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93D4A1A478C64F8880867735 /* Models.swift */; };
+		4F6902ABCD4A7F4256870FE5 /* ViewModelWithLocalState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B8F1BC0D3FBA46773525E84 /* ViewModelWithLocalState.swift */; };
+		53457ECCD4BA391793A532A4 /* Media.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A7FF272B1D54329FB9BF586D /* Media.xcassets */; };
+		538A8AEB23552A33DEF9C4D1 /* AppNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3B5C14B35229275616273E /* AppNavigation.swift */; };
+		5554244BA2E5BDEB707522A1 /* ViewControllerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59ECAEB502AE75799ED65FCC /* ViewControllerSpec.swift */; };
+		5BC6BBF5CAEB1CE3F0AB3535 /* DataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B486EF6BA3C293C3AD8DA1A /* DataSource.swift */; };
+		5BE70BFF41B5170109AD25B6 /* Tempura.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F1184881A6C5AA7E0CBA1142 /* Tempura.framework */; };
+		5BF9171805C335A6977AF83C /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2B04E9E3A5DC3C1280EEF96 /* UIKit.framework */; };
+		5D30A3E14F8A0C4A9060F4FF /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A068A7E777A32BE636AE96F7 /* Foundation.framework */; };
+		63637407D04D49B3F0785AB9 /* Demo.app in Frameworks */ = {isa = PBXBuildFile; fileRef = 49F235E83EED0D8146311428 /* Demo.app */; };
+		637E9C11E350B9F18119B158 /* String+Random.swift in Sources */ = {isa = PBXBuildFile; fileRef = B723380E4DB27859D4494A03 /* String+Random.swift */; };
+		64D4F0C51044C5AA250502F1 /* MainThread.swift in Sources */ = {isa = PBXBuildFile; fileRef = 703FB33C4C6E02B5CCD44130 /* MainThread.swift */; };
+		6A2A3BD02A52FC780CE2DC10 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C831BD0E4860F7AD933817DE /* AppDelegate.swift */; };
+		721B58555A7E0C2BDBBCA1DB /* Tempura.h in Headers */ = {isa = PBXBuildFile; fileRef = F71DE840B39752FCE054B291 /* Tempura.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		74F3EEC13FD7FA9028A44E5D /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43FC6AF877E3D1E1C573ED8E /* AppState.swift */; };
+		7587370463AC5DC6778B7E15 /* UITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 411892F6257A13075A6DE9D3 /* UITests.swift */; };
+		78648662DB59EAB13ADA0ED6 /* UIView+snapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = C74B35841C695FE369AA61B9 /* UIView+snapshot.swift */; };
+		80C66179FC0413BDA3A2F525 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2B04E9E3A5DC3C1280EEF96 /* UIKit.framework */; };
+		835C27AAF63C9C63AD4CC521 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A068A7E777A32BE636AE96F7 /* Foundation.framework */; };
+		8A6E57CE75D1ACB5C44704B9 /* ConfigurableCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A862F946946EC5123FEAA29 /* ConfigurableCell.swift */; };
+		8D07082C4874B398BF39E5AA /* UIView+Blink.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF997DAF1E723495D9042F19 /* UIView+Blink.swift */; };
+		8D8685C328EFC424D283E421 /* ItemActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C4E326A4ABFA4C47965B9BF /* ItemActions.swift */; };
+		8EFA54F1CDD0F371BCE7E3BF /* ViewControllerModellableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02374EEF02DDFF5AA0F61E37 /* ViewControllerModellableView.swift */; };
+		973F983E0C5AF24F75709B4C /* ViewModelWithState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B80B19F0993FF6C18665C70 /* ViewModelWithState.swift */; };
+		9800AE746CA0B8FA80918051 /* LocalState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 046D0F45CAF4C076B44378FC /* LocalState.swift */; };
+		993223EF813A314DFFEA2D7E /* AppActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E5EE7D9D5C149DED30D3122 /* AppActions.swift */; };
+		9EAD87D72487FC7DA65B6A3F /* CGRect+Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96800F24E222C6DB779D339E /* CGRect+Utils.swift */; };
+		9F4D41229A956E6C31D8E2F3 /* NavigationActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FCA6F0E4241D0FBA7AD8C9 /* NavigationActions.swift */; };
+		A89349BB2D1969598942BC53 /* ListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC627CE5B1C6444844358AA /* ListView.swift */; };
+		A9ED186657C0EABBD4D53298 /* Navigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB23A93390A61F4B1578FD27 /* Navigator.swift */; };
+		AEB74A4AF22277D14C039AB6 /* UIControl+TargetActionable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92E22D2E94CA28D6BCAE59F4 /* UIControl+TargetActionable.swift */; };
+		AF9B94BFEEFFA37B331D4D76 /* Pods_TempuraTesting.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0C8A1111F4D42E83BDE6022D /* Pods_TempuraTesting.framework */; };
+		B12D764A3DC40C34A6307AF8 /* TodoCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ED21C2A91CCD05EF9E80453 /* TodoCell.swift */; };
+		B3A632370BC5578F533D4440 /* NavigationDSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2207BA70818350B086E16C4 /* NavigationDSL.swift */; };
+		B47DBA69D0574CD761F9EEAE /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A068A7E777A32BE636AE96F7 /* Foundation.framework */; };
+		B7CDF2C0714B0D85325230D8 /* AddItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B1A1E37A368ED70225277D6 /* AddItemView.swift */; };
+		BD50738222241CC702D98845 /* String+Height.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF31A3D61A640BF7BE456C7A /* String+Height.swift */; };
+		C01195CE453015E6D584BDC8 /* NavigationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 361F637C9075217C1EA3C742 /* NavigationProvider.swift */; };
+		C121D1C4240BB081764B0C19 /* RootInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4171BF68D9C8D22A5A4D1D79 /* RootInstaller.swift */; };
+		C370C0B66F3390BA57B28586 /* DependenciesContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D267050F2759FB614643A1CA /* DependenciesContainer.swift */; };
+		CE61C7880E35F95676729DAD /* AsyncUITest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9616C4802BAEBA68CFFBF6C1 /* AsyncUITest.swift */; };
+		CFC994F1EF51845CDD36D199 /* Tempura.h in Headers */ = {isa = PBXBuildFile; fileRef = F71DE840B39752FCE054B291 /* Tempura.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D57DD2D899C37215FCF8A63B /* Pods_Tempura.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FD7E6BAC37BCB0CF99B72EFB /* Pods_Tempura.framework */; };
+		DC0928F25485BC9B3DD23881 /* ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5933E321276871DCE3DA1EB5 /* ViewModel.swift */; };
+		E0113A5B1FF0F1242EFB2EDD /* ListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C74D89702FC5977AD46F8625 /* ListViewController.swift */; };
+		E23BB6BF7C80F05FB709FAD4 /* TodoFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03BFCBB5A04BE02F87879EAC /* TodoFlowLayout.swift */; };
+		E6A48E5886DA6C2FDFDE7EEB /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2B04E9E3A5DC3C1280EEF96 /* UIKit.framework */; };
+		E9A816CA2CBE1DB85C642D1B /* Pods_Tempura_Demo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 014BB2A1BE317151FB012501 /* Pods_Tempura_Demo.framework */; };
+		EACBFA791F7253DC6647F072 /* Pods_DemoTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C9BA1DB585FEC92C018C563C /* Pods_DemoTests.framework */; };
+		EB362A879F88C8C3B9FFF865 /* Pods_TempuraTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 48308C9CE5862566FB4A65E3 /* Pods_TempuraTests.framework */; };
+		F9708DABDDFAE060D7367112 /* View.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDBA2BEFFB6A124F1CC03D3B /* View.swift */; };
+		FA3F30DF3B72E655E05D62B7 /* ViewControllerWithLocalState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AD9BD6611FD22D5D0907A85 /* ViewControllerWithLocalState.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		0EC67DAE2C4AC94C701AC8F7 /* PBXContainerItemProxy */ = {
+		A2213B5F162F3920DF7E7A00 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 744F8DC1C2ECD6BC4C6D9F61 /* Project object */;
+			containerPortal = 21B81D37BB06880DEACF8ABF /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = FA1682828A9B8F1B00F69236;
+			remoteGlobalIDString = 68D33A3A28DA49773E5AC0DC;
 			remoteInfo = Tempura;
 		};
-		9F7A192C14D6B8BC49B87A30 /* PBXContainerItemProxy */ = {
+		BD40FFEE3DAB19A8158E1F1F /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 744F8DC1C2ECD6BC4C6D9F61 /* Project object */;
+			containerPortal = 21B81D37BB06880DEACF8ABF /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = FA1682828A9B8F1B00F69236;
+			remoteGlobalIDString = 68D33A3A28DA49773E5AC0DC;
 			remoteInfo = Tempura;
 		};
-		E5EA61DB471C25D14B38AD16 /* PBXContainerItemProxy */ = {
+		D0BBFC0F4FD77E279E2AF790 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 744F8DC1C2ECD6BC4C6D9F61 /* Project object */;
+			containerPortal = 21B81D37BB06880DEACF8ABF /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 0C7439E922866219444DC052;
+			remoteGlobalIDString = E05343300C78F97F1748725A;
 			remoteInfo = Demo;
 		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		01E2F772ED2425A3C51BA35B /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS11.3.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		09BD506EA6A14312C94320AF /* Pods-TempuraTesting.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TempuraTesting.debug.xcconfig"; path = "Pods/Target Support Files/Pods-TempuraTesting/Pods-TempuraTesting.debug.xcconfig"; sourceTree = "<group>"; };
-		0E44A8B6B91E848D7C197F88 /* AddItemViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AddItemViewController.swift; sourceTree = "<group>"; };
-		16EFCD7BA9311BA2EF5486BE /* NavigationActions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NavigationActions.swift; sourceTree = "<group>"; };
-		1B6B7FC64E60C11B94A2902D /* AppDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		1C67EB1DECD1DC32B8FBC98F /* Tempura.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Tempura.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		1D888A7D92B83D5EE00C7877 /* ViewControllerWithLocalState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewControllerWithLocalState.swift; sourceTree = "<group>"; };
-		268CA34D277FB8EF167F5E2A /* LocalFileURLProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LocalFileURLProtocol.swift; sourceTree = "<group>"; };
-		36FF4555ABB519D77C62D3A4 /* String+Random.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "String+Random.swift"; sourceTree = "<group>"; };
-		381FA20B59C6346F4DC398F8 /* TempuraTesting.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TempuraTesting.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		3BBE5AA2DB1AA57D18D4C3FE /* Pods-DemoTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DemoTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-DemoTests/Pods-DemoTests.debug.xcconfig"; sourceTree = "<group>"; };
-		3BF1CD666FA56629F1DC5D39 /* TodoFlowLayout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TodoFlowLayout.swift; sourceTree = "<group>"; };
-		3E6BBCD79E966D1F43FF6A2A /* ModellableView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ModellableView.swift; sourceTree = "<group>"; };
-		3FD26121728299DA6907967E /* Models.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Models.swift; sourceTree = "<group>"; };
-		43DB747145736860CDD24B3B /* ViewModelWithState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewModelWithState.swift; sourceTree = "<group>"; };
-		482630945BAF553C141B76D1 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS11.3.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
-		57CC57E8577FB471F766CBED /* NavigationDSL.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NavigationDSL.swift; sourceTree = "<group>"; };
-		587850D7F800CF538EEE2A83 /* Pods_DemoTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_DemoTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		595C2F826BCE63F865944A89 /* UIView+snapshot.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "UIView+snapshot.swift"; sourceTree = "<group>"; };
-		5A011D32DDB9A66339BB8328 /* DemoTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DemoTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		5A07C54A54D8E027DA00C353 /* CGRect+Utils.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "CGRect+Utils.swift"; sourceTree = "<group>"; };
-		60F537A90B62D747C9AA7A8E /* ItemActions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ItemActions.swift; sourceTree = "<group>"; };
-		631F5874534FFC3732CBC19D /* NavigationUtilities.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NavigationUtilities.swift; sourceTree = "<group>"; };
-		639591CE1428B88CD4B5B159 /* Pods-DemoTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DemoTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-DemoTests/Pods-DemoTests.release.xcconfig"; sourceTree = "<group>"; };
-		63E5CE8DDD9025A97C3BE5F9 /* UIControl+TargetActionable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "UIControl+TargetActionable.swift"; sourceTree = "<group>"; };
-		672A284CF0A423F452DFB2DB /* Pods-Tempura-Demo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tempura-Demo.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Tempura-Demo/Pods-Tempura-Demo.debug.xcconfig"; sourceTree = "<group>"; };
-		6D585DFB8C1983F404427C7B /* ViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
-		6E8033671A8A7963E389304A /* TempuraTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TempuraTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		6EE19A3969331B748D2642ED /* AppNavigation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppNavigation.swift; sourceTree = "<group>"; };
-		6F51E193225CE2C0CC58D843 /* Pods-TempuraTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TempuraTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-TempuraTests/Pods-TempuraTests.release.xcconfig"; sourceTree = "<group>"; };
-		7180309A39E4F8186CC96AB5 /* Media.xcassets */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder.assetcatalog; path = Media.xcassets; sourceTree = "<group>"; };
-		72DDFE41A333A7BF0DC291C9 /* Pods_TempuraTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TempuraTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		74773A038BE50FDB8C48B29C /* ViewControllerModellableView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewControllerModellableView.swift; sourceTree = "<group>"; };
-		8085F32D3577898B62F727C0 /* ViewModelWithLocalState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewModelWithLocalState.swift; sourceTree = "<group>"; };
-		88E46B566D70E08C3E60ADE5 /* ViewControllerWithLocalState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewControllerWithLocalState.swift; sourceTree = "<group>"; };
-		8A11636FCE0CB71011EE787E /* CollectionView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CollectionView.swift; sourceTree = "<group>"; };
-		8A60147674CB769C5FB573F1 /* AsyncUITest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AsyncUITest.swift; sourceTree = "<group>"; };
-		8D97907AFB59F527978BA88A /* Routable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Routable.swift; sourceTree = "<group>"; };
-		8FD4588D8F66A1888833E983 /* Pods-TempuraTesting.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TempuraTesting.release.xcconfig"; path = "Pods/Target Support Files/Pods-TempuraTesting/Pods-TempuraTesting.release.xcconfig"; sourceTree = "<group>"; };
-		9545FB7230C045BF66A44D21 /* ViewControllerSpec.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewControllerSpec.swift; sourceTree = "<group>"; };
-		97435C6E6CCD57CBD2C3D060 /* Pods-Tempura.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tempura.release.xcconfig"; path = "Pods/Target Support Files/Pods-Tempura/Pods-Tempura.release.xcconfig"; sourceTree = "<group>"; };
-		9A5948CAEDCE97F17AE86864 /* LocalState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LocalState.swift; sourceTree = "<group>"; };
-		9AFA6BB18AE2564A37890F83 /* Pods-Tempura.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tempura.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Tempura/Pods-Tempura.debug.xcconfig"; sourceTree = "<group>"; };
-		9B2642949D2EA50F68450D2F /* ListView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ListView.swift; sourceTree = "<group>"; };
-		9D782DC558DB2AFC44D3324C /* TextView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TextView.swift; sourceTree = "<group>"; };
-		A6DA550B8A8326AB98C04AA1 /* Pods_Tempura_Demo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Tempura_Demo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		AC4E45A155B29BE07953C811 /* ArchiveFlowLayout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ArchiveFlowLayout.swift; sourceTree = "<group>"; };
-		AC88326A32EE77E9A36B8DD8 /* RootInstaller.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RootInstaller.swift; sourceTree = "<group>"; };
-		AEED91B30AFC547F5732A274 /* String+Height.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "String+Height.swift"; sourceTree = "<group>"; };
-		AEF91CA7FC7EE66EFFB4EB2E /* ViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewModel.swift; sourceTree = "<group>"; };
-		B49FFD6DE4EDCCE4123697EF /* Pods-TempuraTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TempuraTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-TempuraTests/Pods-TempuraTests.debug.xcconfig"; sourceTree = "<group>"; };
-		B4D49F37A6EEB01D053F7784 /* AppActions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppActions.swift; sourceTree = "<group>"; };
-		B65B063D8BBBD5F462EDC289 /* Demo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Demo.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		B7EAEC5D537BAE8561945346 /* Pods_Tempura.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Tempura.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		BE698AA550F7FA01BC257027 /* Source.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Source.swift; sourceTree = "<group>"; };
-		C01B95502FF0868DCED4E267 /* UITests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UITests.swift; sourceTree = "<group>"; };
-		C0D1314E6A2A2F4285B98FC2 /* ListViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ListViewController.swift; sourceTree = "<group>"; };
-		C4BB637B188E7E5ACA1EB81F /* DataSource.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DataSource.swift; sourceTree = "<group>"; };
-		CBF0FC91E393CB5C7BB828F9 /* AppState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
-		CD3CCC90CE97F278909BD834 /* NavigationProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NavigationProvider.swift; sourceTree = "<group>"; };
-		D854F243A699251C097F3659 /* Tempura.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = Tempura.h; sourceTree = "<group>"; };
-		DAA15836F6B3D87BE1FAD771 /* View.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = View.swift; sourceTree = "<group>"; };
-		DC2176216F33A18854B82714 /* TodoCell.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TodoCell.swift; sourceTree = "<group>"; };
-		DF865F48BBFF042F297B7F2C /* DemoTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DemoTests.swift; sourceTree = "<group>"; };
-		E066F66649DC2B77B487DEBC /* DependenciesContainer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DependenciesContainer.swift; sourceTree = "<group>"; };
-		EAD88A27255297A902591032 /* UIView+Blink.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "UIView+Blink.swift"; sourceTree = "<group>"; };
-		EDFDA1ECAD8573D520306050 /* Navigator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Navigator.swift; sourceTree = "<group>"; };
-		F09881D30E865B17BCCC778F /* AddItemView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AddItemView.swift; sourceTree = "<group>"; };
-		F7368059D2F2383A9C8771B3 /* MainThread.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MainThread.swift; sourceTree = "<group>"; };
-		FBF527EEA9D82E7D88E04C9E /* Pods_TempuraTesting.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TempuraTesting.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		FEFD4C1CFEFFA69152127667 /* Pods-Tempura-Demo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tempura-Demo.release.xcconfig"; path = "Pods/Target Support Files/Pods-Tempura-Demo/Pods-Tempura-Demo.release.xcconfig"; sourceTree = "<group>"; };
-		FFD0777D7421F68D73BB8132 /* ConfigurableCell.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConfigurableCell.swift; sourceTree = "<group>"; };
+		014BB2A1BE317151FB012501 /* Pods_Tempura_Demo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Tempura_Demo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		02374EEF02DDFF5AA0F61E37 /* ViewControllerModellableView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewControllerModellableView.swift; sourceTree = "<group>"; };
+		03BFCBB5A04BE02F87879EAC /* TodoFlowLayout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TodoFlowLayout.swift; sourceTree = "<group>"; };
+		046D0F45CAF4C076B44378FC /* LocalState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LocalState.swift; sourceTree = "<group>"; };
+		0B80B19F0993FF6C18665C70 /* ViewModelWithState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewModelWithState.swift; sourceTree = "<group>"; };
+		0C8A1111F4D42E83BDE6022D /* Pods_TempuraTesting.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TempuraTesting.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		19ECEE9F71660063E140E9D8 /* Pods-Tempura.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tempura.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Tempura/Pods-Tempura.debug.xcconfig"; sourceTree = "<group>"; };
+		1FBF9E1958499386813B3655 /* Pods-TempuraTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TempuraTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-TempuraTests/Pods-TempuraTests.release.xcconfig"; sourceTree = "<group>"; };
+		235626D6A3B2F180FBA18922 /* Pods-TempuraTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TempuraTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-TempuraTests/Pods-TempuraTests.debug.xcconfig"; sourceTree = "<group>"; };
+		263FE4C84B71DD4E96506B71 /* CollectionView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CollectionView.swift; sourceTree = "<group>"; };
+		26FCA6F0E4241D0FBA7AD8C9 /* NavigationActions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NavigationActions.swift; sourceTree = "<group>"; };
+		2AD9BD6611FD22D5D0907A85 /* ViewControllerWithLocalState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewControllerWithLocalState.swift; sourceTree = "<group>"; };
+		2B486EF6BA3C293C3AD8DA1A /* DataSource.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DataSource.swift; sourceTree = "<group>"; };
+		32CBB43468E3367CB492834E /* TextView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TextView.swift; sourceTree = "<group>"; };
+		361F637C9075217C1EA3C742 /* NavigationProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NavigationProvider.swift; sourceTree = "<group>"; };
+		3A862F946946EC5123FEAA29 /* ConfigurableCell.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConfigurableCell.swift; sourceTree = "<group>"; };
+		411892F6257A13075A6DE9D3 /* UITests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UITests.swift; sourceTree = "<group>"; };
+		4171BF68D9C8D22A5A4D1D79 /* RootInstaller.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RootInstaller.swift; sourceTree = "<group>"; };
+		436316A65E092D4E747F4B23 /* AddItemViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AddItemViewController.swift; sourceTree = "<group>"; };
+		43FC6AF877E3D1E1C573ED8E /* AppState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
+		47E6CF03C58E0FDB7E111C2C /* ViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		48308C9CE5862566FB4A65E3 /* Pods_TempuraTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TempuraTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		4853973B62E0006AAE393402 /* Pods-TempuraTesting.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TempuraTesting.release.xcconfig"; path = "Pods/Target Support Files/Pods-TempuraTesting/Pods-TempuraTesting.release.xcconfig"; sourceTree = "<group>"; };
+		49F235E83EED0D8146311428 /* Demo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Demo.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		4B1A1E37A368ED70225277D6 /* AddItemView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AddItemView.swift; sourceTree = "<group>"; };
+		4E5EE7D9D5C149DED30D3122 /* AppActions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppActions.swift; sourceTree = "<group>"; };
+		5933E321276871DCE3DA1EB5 /* ViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewModel.swift; sourceTree = "<group>"; };
+		59ECAEB502AE75799ED65FCC /* ViewControllerSpec.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewControllerSpec.swift; sourceTree = "<group>"; };
+		5B8F1BC0D3FBA46773525E84 /* ViewModelWithLocalState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewModelWithLocalState.swift; sourceTree = "<group>"; };
+		5C4E326A4ABFA4C47965B9BF /* ItemActions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ItemActions.swift; sourceTree = "<group>"; };
+		5DA715507108DB2672BBD42E /* TempuraTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TempuraTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		5ED21C2A91CCD05EF9E80453 /* TodoCell.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TodoCell.swift; sourceTree = "<group>"; };
+		6835FEE2AC44016AB6BB8B3B /* Pods-DemoTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DemoTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-DemoTests/Pods-DemoTests.release.xcconfig"; sourceTree = "<group>"; };
+		6F3396E6D30E2168C028BBC7 /* Source.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Source.swift; sourceTree = "<group>"; };
+		703FB33C4C6E02B5CCD44130 /* MainThread.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MainThread.swift; sourceTree = "<group>"; };
+		7619E7499D0198D451B727E8 /* LocalFileURLProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LocalFileURLProtocol.swift; sourceTree = "<group>"; };
+		87ED865E4F59019AC2D16CAC /* Pods-Tempura.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tempura.release.xcconfig"; path = "Pods/Target Support Files/Pods-Tempura/Pods-Tempura.release.xcconfig"; sourceTree = "<group>"; };
+		896CD79E2C85799883633430 /* Pods-TempuraTesting.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TempuraTesting.debug.xcconfig"; path = "Pods/Target Support Files/Pods-TempuraTesting/Pods-TempuraTesting.debug.xcconfig"; sourceTree = "<group>"; };
+		8976A233755FF97E27755795 /* DemoTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DemoTests.swift; sourceTree = "<group>"; };
+		8A3B5C14B35229275616273E /* AppNavigation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppNavigation.swift; sourceTree = "<group>"; };
+		92E22D2E94CA28D6BCAE59F4 /* UIControl+TargetActionable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "UIControl+TargetActionable.swift"; sourceTree = "<group>"; };
+		93D4A1A478C64F8880867735 /* Models.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Models.swift; sourceTree = "<group>"; };
+		951F01D47E0B6B5304B54CFD /* DemoTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DemoTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		9616C4802BAEBA68CFFBF6C1 /* AsyncUITest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AsyncUITest.swift; sourceTree = "<group>"; };
+		96800F24E222C6DB779D339E /* CGRect+Utils.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "CGRect+Utils.swift"; sourceTree = "<group>"; };
+		968F894C2347D8661A4849EA /* TempuraTesting.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TempuraTesting.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		A068A7E777A32BE636AE96F7 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS11.3.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		A45E0875535580941275E976 /* NavigationUtilities.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NavigationUtilities.swift; sourceTree = "<group>"; };
+		A7FF272B1D54329FB9BF586D /* Media.xcassets */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder.assetcatalog; path = Media.xcassets; sourceTree = "<group>"; };
+		ADD2E91D1642F6AC34DD5DA1 /* Pods-Tempura-Demo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tempura-Demo.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Tempura-Demo/Pods-Tempura-Demo.debug.xcconfig"; sourceTree = "<group>"; };
+		AF31A3D61A640BF7BE456C7A /* String+Height.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "String+Height.swift"; sourceTree = "<group>"; };
+		B08F0E49B2120828BF14CBF5 /* ModellableView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ModellableView.swift; sourceTree = "<group>"; };
+		B2207BA70818350B086E16C4 /* NavigationDSL.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NavigationDSL.swift; sourceTree = "<group>"; };
+		B6F41B29DFC62B2985C10B45 /* ArchiveFlowLayout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ArchiveFlowLayout.swift; sourceTree = "<group>"; };
+		B723380E4DB27859D4494A03 /* String+Random.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "String+Random.swift"; sourceTree = "<group>"; };
+		BF997DAF1E723495D9042F19 /* UIView+Blink.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "UIView+Blink.swift"; sourceTree = "<group>"; };
+		C74B35841C695FE369AA61B9 /* UIView+snapshot.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "UIView+snapshot.swift"; sourceTree = "<group>"; };
+		C74D89702FC5977AD46F8625 /* ListViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ListViewController.swift; sourceTree = "<group>"; };
+		C831BD0E4860F7AD933817DE /* AppDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		C9BA1DB585FEC92C018C563C /* Pods_DemoTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_DemoTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		CAC627CE5B1C6444844358AA /* ListView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ListView.swift; sourceTree = "<group>"; };
+		CB23A93390A61F4B1578FD27 /* Navigator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Navigator.swift; sourceTree = "<group>"; };
+		D267050F2759FB614643A1CA /* DependenciesContainer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DependenciesContainer.swift; sourceTree = "<group>"; };
+		D2B04E9E3A5DC3C1280EEF96 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS11.3.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
+		D36EE94D33BF3422F158EF1C /* Routable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Routable.swift; sourceTree = "<group>"; };
+		D9B2CE9D5CC2452E7F3F8FE4 /* ViewControllerWithLocalState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewControllerWithLocalState.swift; sourceTree = "<group>"; };
+		DDBA2BEFFB6A124F1CC03D3B /* View.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = View.swift; sourceTree = "<group>"; };
+		E4F8CBDF73FA344BBF17B448 /* Pods-DemoTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DemoTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-DemoTests/Pods-DemoTests.debug.xcconfig"; sourceTree = "<group>"; };
+		F1184881A6C5AA7E0CBA1142 /* Tempura.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Tempura.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		F71DE840B39752FCE054B291 /* Tempura.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = Tempura.h; sourceTree = "<group>"; };
+		FA875DE51554C30103AD02D5 /* Pods-Tempura-Demo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tempura-Demo.release.xcconfig"; path = "Pods/Target Support Files/Pods-Tempura-Demo/Pods-Tempura-Demo.release.xcconfig"; sourceTree = "<group>"; };
+		FD7E6BAC37BCB0CF99B72EFB /* Pods_Tempura.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Tempura.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		4E9115B4CB89ADAC7933D3BE /* Frameworks */ = {
+		04F36E965BE36422FC8B2601 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E888F44E4CE4F3E3EF334C12 /* Foundation.framework in Frameworks */,
-				24ADA1B4A3967EF79994CB2E /* UIKit.framework in Frameworks */,
-				E2AD5EDE0607E39BDF2D91DD /* Tempura.framework in Frameworks */,
-				F828C365D1896266017301E3 /* Pods_TempuraTests.framework in Frameworks */,
+				5D30A3E14F8A0C4A9060F4FF /* Foundation.framework in Frameworks */,
+				80C66179FC0413BDA3A2F525 /* UIKit.framework in Frameworks */,
+				5BE70BFF41B5170109AD25B6 /* Tempura.framework in Frameworks */,
+				EB362A879F88C8C3B9FFF865 /* Pods_TempuraTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		8D92F13CAB5B6288279D7852 /* Frameworks */ = {
+		176B980F23E383060ECED5FA /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3178E1307B8714BDC91E86DF /* Foundation.framework in Frameworks */,
-				7370D3231701EDEC37F700C7 /* UIKit.framework in Frameworks */,
-				01F10E973C03D7C684CAABA2 /* Pods_TempuraTesting.framework in Frameworks */,
+				2542575AB7E5E10F132A9660 /* Foundation.framework in Frameworks */,
+				E6A48E5886DA6C2FDFDE7EEB /* UIKit.framework in Frameworks */,
+				63637407D04D49B3F0785AB9 /* Demo.app in Frameworks */,
+				EACBFA791F7253DC6647F072 /* Pods_DemoTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		D69D214182E648F5B316B8D8 /* Frameworks */ = {
+		216DBA50DEA3A4C632983D66 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6648260C83F58CAF6E03802D /* Foundation.framework in Frameworks */,
-				DBEDC6FB7DB65ABF94664A5A /* UIKit.framework in Frameworks */,
-				44F41A5BB782CA4908E2DC6F /* Pods_Tempura.framework in Frameworks */,
+				B47DBA69D0574CD761F9EEAE /* Foundation.framework in Frameworks */,
+				4A6BDEB84E556AAC89445F29 /* UIKit.framework in Frameworks */,
+				AF9B94BFEEFFA37B331D4D76 /* Pods_TempuraTesting.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		D9003A41BF6883F1D0436279 /* Frameworks */ = {
+		2DB24F4575FABC05508E5289 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				150D2AB10915E6563FECD62C /* Foundation.framework in Frameworks */,
-				251F7D394654B7829D2B9AA8 /* UIKit.framework in Frameworks */,
-				32AB0F183C1ADC7621F1DAD9 /* Tempura.framework in Frameworks */,
-				05080C1534BF13CAB2D30021 /* Pods_Tempura_Demo.framework in Frameworks */,
+				384EF477FC7D61339F8A314A /* Foundation.framework in Frameworks */,
+				3BA3D2466DE388ABD9A067E6 /* UIKit.framework in Frameworks */,
+				4B8DBA6D00BF78753B58499F /* Tempura.framework in Frameworks */,
+				E9A816CA2CBE1DB85C642D1B /* Pods_Tempura_Demo.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		DE797355A59F33B9C584EC89 /* Frameworks */ = {
+		7B087CACCEAE8EB6C0C8EE3F /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				86F882987AEF281D66C45E0B /* Foundation.framework in Frameworks */,
-				412C25513119ADF5DE7624AD /* UIKit.framework in Frameworks */,
-				E3754E56157F83483F7D3099 /* Demo.app in Frameworks */,
-				718E36C65915D91064B99B9F /* Pods_DemoTests.framework in Frameworks */,
+				835C27AAF63C9C63AD4CC521 /* Foundation.framework in Frameworks */,
+				5BF9171805C335A6977AF83C /* UIKit.framework in Frameworks */,
+				D57DD2D899C37215FCF8A63B /* Pods_Tempura.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		075320B21BC713C0DCE47A0A /* Dependencies */ = {
+		0002B80022F240B2DFE7F7C9 /* SupportingFiles */ = {
 			isa = PBXGroup;
 			children = (
-				E066F66649DC2B77B487DEBC /* DependenciesContainer.swift */,
-			);
-			name = Dependencies;
-			path = Dependencies;
-			sourceTree = "<group>";
-		};
-		0ECBF4614847D14EBB3C68A6 /* TempuraTests */ = {
-			isa = PBXGroup;
-			children = (
-				9545FB7230C045BF66A44D21 /* ViewControllerSpec.swift */,
-				88E46B566D70E08C3E60ADE5 /* ViewControllerWithLocalState.swift */,
-			);
-			name = TempuraTests;
-			path = TempuraTests;
-			sourceTree = "<group>";
-		};
-		1FE36FFC6A6748F9E065ECD8 /* DemoTests */ = {
-			isa = PBXGroup;
-			children = (
-				DF865F48BBFF042F297B7F2C /* DemoTests.swift */,
-			);
-			name = DemoTests;
-			path = DemoTests;
-			sourceTree = "<group>";
-		};
-		1FEA2B3E7AAD4E16A9154F06 /* Navigation */ = {
-			isa = PBXGroup;
-			children = (
-				6EE19A3969331B748D2642ED /* AppNavigation.swift */,
-			);
-			name = Navigation;
-			path = Navigation;
-			sourceTree = "<group>";
-		};
-		3A4542BD989BC077AE310B6F /* Subviews */ = {
-			isa = PBXGroup;
-			children = (
-				AC4E45A155B29BE07953C811 /* ArchiveFlowLayout.swift */,
-				DC2176216F33A18854B82714 /* TodoCell.swift */,
-				3BF1CD666FA56629F1DC5D39 /* TodoFlowLayout.swift */,
-			);
-			name = Subviews;
-			path = Subviews;
-			sourceTree = "<group>";
-		};
-		4B3FEFCCA0C2591C93C14774 /* CollectionView */ = {
-			isa = PBXGroup;
-			children = (
-				BE698AA550F7FA01BC257027 /* Source.swift */,
-				8A11636FCE0CB71011EE787E /* CollectionView.swift */,
-				C4BB637B188E7E5ACA1EB81F /* DataSource.swift */,
-				FFD0777D7421F68D73BB8132 /* ConfigurableCell.swift */,
-			);
-			name = CollectionView;
-			path = CollectionView;
-			sourceTree = "<group>";
-		};
-		549617DD9890AC033A76B86D /* Core */ = {
-			isa = PBXGroup;
-			children = (
-				6D585DFB8C1983F404427C7B /* ViewController.swift */,
-				DAA15836F6B3D87BE1FAD771 /* View.swift */,
-				43DB747145736860CDD24B3B /* ViewModelWithState.swift */,
-				3E6BBCD79E966D1F43FF6A2A /* ModellableView.swift */,
-				8085F32D3577898B62F727C0 /* ViewModelWithLocalState.swift */,
-				9A5948CAEDCE97F17AE86864 /* LocalState.swift */,
-				AEF91CA7FC7EE66EFFB4EB2E /* ViewModel.swift */,
-				74773A038BE50FDB8C48B29C /* ViewControllerModellableView.swift */,
-				1D888A7D92B83D5EE00C7877 /* ViewControllerWithLocalState.swift */,
-			);
-			name = Core;
-			path = Core;
-			sourceTree = "<group>";
-		};
-		564D926F2CED2298B343FFCF /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				3BBE5AA2DB1AA57D18D4C3FE /* Pods-DemoTests.debug.xcconfig */,
-				639591CE1428B88CD4B5B159 /* Pods-DemoTests.release.xcconfig */,
-				9AFA6BB18AE2564A37890F83 /* Pods-Tempura.debug.xcconfig */,
-				97435C6E6CCD57CBD2C3D060 /* Pods-Tempura.release.xcconfig */,
-				672A284CF0A423F452DFB2DB /* Pods-Tempura-Demo.debug.xcconfig */,
-				FEFD4C1CFEFFA69152127667 /* Pods-Tempura-Demo.release.xcconfig */,
-				09BD506EA6A14312C94320AF /* Pods-TempuraTesting.debug.xcconfig */,
-				8FD4588D8F66A1888833E983 /* Pods-TempuraTesting.release.xcconfig */,
-				B49FFD6DE4EDCCE4123697EF /* Pods-TempuraTests.debug.xcconfig */,
-				6F51E193225CE2C0CC58D843 /* Pods-TempuraTests.release.xcconfig */,
-			);
-			name = Pods;
-			sourceTree = "<group>";
-		};
-		5816348C7B8FDB68CF69C698 /* Navigation */ = {
-			isa = PBXGroup;
-			children = (
-				16EFCD7BA9311BA2EF5486BE /* NavigationActions.swift */,
-				631F5874534FFC3732CBC19D /* NavigationUtilities.swift */,
-				8D97907AFB59F527978BA88A /* Routable.swift */,
-				AC88326A32EE77E9A36B8DD8 /* RootInstaller.swift */,
-				57CC57E8577FB471F766CBED /* NavigationDSL.swift */,
-				CD3CCC90CE97F278909BD834 /* NavigationProvider.swift */,
-				EDFDA1ECAD8573D520306050 /* Navigator.swift */,
-			);
-			name = Navigation;
-			path = Navigation;
-			sourceTree = "<group>";
-		};
-		6E5EFF7E2B5D7932A48A1C8B /* AddItemScreen */ = {
-			isa = PBXGroup;
-			children = (
-				B93A4BC2ED1F969F9410BFD9 /* Subviews */,
-				F09881D30E865B17BCCC778F /* AddItemView.swift */,
-				0E44A8B6B91E848D7C197F88 /* AddItemViewController.swift */,
-			);
-			name = AddItemScreen;
-			path = AddItemScreen;
-			sourceTree = "<group>";
-		};
-		87B66A12E92236A841A0644B /* State */ = {
-			isa = PBXGroup;
-			children = (
-				CBF0FC91E393CB5C7BB828F9 /* AppState.swift */,
-				3FD26121728299DA6907967E /* Models.swift */,
-			);
-			name = State;
-			path = State;
-			sourceTree = "<group>";
-		};
-		90D89354CBF32246FC50B7ED = {
-			isa = PBXGroup;
-			children = (
-				A63D8F9BDD9B3CD50F188017 /* Products */,
-				C8E2D57E36579BBDC81EC10D /* Frameworks */,
-				0ECBF4614847D14EBB3C68A6 /* TempuraTests */,
-				B0859DAF61ABCDC0AB314BDF /* Tempura */,
-				1FE36FFC6A6748F9E065ECD8 /* DemoTests */,
-				BA2AE93006BAC5EE87F3AEF1 /* Demo */,
-				564D926F2CED2298B343FFCF /* Pods */,
-			);
-			sourceTree = "<group>";
-		};
-		A63D8F9BDD9B3CD50F188017 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				6E8033671A8A7963E389304A /* TempuraTests.xctest */,
-				1C67EB1DECD1DC32B8FBC98F /* Tempura.framework */,
-				381FA20B59C6346F4DC398F8 /* TempuraTesting.framework */,
-				5A011D32DDB9A66339BB8328 /* DemoTests.xctest */,
-				B65B063D8BBBD5F462EDC289 /* Demo.app */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		B0859DAF61ABCDC0AB314BDF /* Tempura */ = {
-			isa = PBXGroup;
-			children = (
-				549617DD9890AC033A76B86D /* Core */,
-				5816348C7B8FDB68CF69C698 /* Navigation */,
-				F63CD8C4427E8DA616894A90 /* Utilities */,
-				D0A0EE11F0EACFD5BA2E8FDA /* UITests */,
-				E04B28324AB1BF7A6BA2E153 /* SupportingFiles */,
-			);
-			name = Tempura;
-			path = Tempura;
-			sourceTree = "<group>";
-		};
-		B93A4BC2ED1F969F9410BFD9 /* Subviews */ = {
-			isa = PBXGroup;
-			children = (
-				9D782DC558DB2AFC44D3324C /* TextView.swift */,
-			);
-			name = Subviews;
-			path = Subviews;
-			sourceTree = "<group>";
-		};
-		BA2AE93006BAC5EE87F3AEF1 /* Demo */ = {
-			isa = PBXGroup;
-			children = (
-				F32B386625798C399D11202A /* UI */,
-				1FEA2B3E7AAD4E16A9154F06 /* Navigation */,
-				075320B21BC713C0DCE47A0A /* Dependencies */,
-				87B66A12E92236A841A0644B /* State */,
-				DBBF8654A6EB13850B77B08D /* Utilities */,
-				F7DAE5583A382B723D51F376 /* Actions */,
-				E9FA1AAE92A8DF84F8EAFFA7 /* Application */,
-				FE04EC9E97818E31051F02B1 /* Resources */,
-			);
-			name = Demo;
-			path = Demo;
-			sourceTree = "<group>";
-		};
-		BC29ECA55AC892C58E746C72 /* iOS */ = {
-			isa = PBXGroup;
-			children = (
-				01E2F772ED2425A3C51BA35B /* Foundation.framework */,
-				482630945BAF553C141B76D1 /* UIKit.framework */,
-			);
-			name = iOS;
-			sourceTree = "<group>";
-		};
-		C8E2D57E36579BBDC81EC10D /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				BC29ECA55AC892C58E746C72 /* iOS */,
-				587850D7F800CF538EEE2A83 /* Pods_DemoTests.framework */,
-				B7EAEC5D537BAE8561945346 /* Pods_Tempura.framework */,
-				A6DA550B8A8326AB98C04AA1 /* Pods_Tempura_Demo.framework */,
-				FBF527EEA9D82E7D88E04C9E /* Pods_TempuraTesting.framework */,
-				72DDFE41A333A7BF0DC291C9 /* Pods_TempuraTests.framework */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		D0A0EE11F0EACFD5BA2E8FDA /* UITests */ = {
-			isa = PBXGroup;
-			children = (
-				C01B95502FF0868DCED4E267 /* UITests.swift */,
-				8A60147674CB769C5FB573F1 /* AsyncUITest.swift */,
-				268CA34D277FB8EF167F5E2A /* LocalFileURLProtocol.swift */,
-				595C2F826BCE63F865944A89 /* UIView+snapshot.swift */,
-			);
-			name = UITests;
-			path = UITests;
-			sourceTree = "<group>";
-		};
-		DBBF8654A6EB13850B77B08D /* Utilities */ = {
-			isa = PBXGroup;
-			children = (
-				63E5CE8DDD9025A97C3BE5F9 /* UIControl+TargetActionable.swift */,
-				36FF4555ABB519D77C62D3A4 /* String+Random.swift */,
-				4B3FEFCCA0C2591C93C14774 /* CollectionView */,
-				5A07C54A54D8E027DA00C353 /* CGRect+Utils.swift */,
-				EAD88A27255297A902591032 /* UIView+Blink.swift */,
-				AEED91B30AFC547F5732A274 /* String+Height.swift */,
-			);
-			name = Utilities;
-			path = Utilities;
-			sourceTree = "<group>";
-		};
-		E04B28324AB1BF7A6BA2E153 /* SupportingFiles */ = {
-			isa = PBXGroup;
-			children = (
-				D854F243A699251C097F3659 /* Tempura.h */,
+				F71DE840B39752FCE054B291 /* Tempura.h */,
 			);
 			name = SupportingFiles;
 			path = SupportingFiles;
 			sourceTree = "<group>";
 		};
-		E9FA1AAE92A8DF84F8EAFFA7 /* Application */ = {
+		06951BFB6A8F7F8F2C547CAB /* Navigation */ = {
 			isa = PBXGroup;
 			children = (
-				1B6B7FC64E60C11B94A2902D /* AppDelegate.swift */,
+				8A3B5C14B35229275616273E /* AppNavigation.swift */,
 			);
-			name = Application;
-			path = Application;
+			name = Navigation;
+			path = Navigation;
 			sourceTree = "<group>";
 		};
-		F0E8F0D3793C9E7F19A742E7 /* ListScreen */ = {
+		1086B828A155BE5C276DA9F0 /* TempuraTests */ = {
 			isa = PBXGroup;
 			children = (
-				C0D1314E6A2A2F4285B98FC2 /* ListViewController.swift */,
-				9B2642949D2EA50F68450D2F /* ListView.swift */,
-				3A4542BD989BC077AE310B6F /* Subviews */,
+				59ECAEB502AE75799ED65FCC /* ViewControllerSpec.swift */,
+				2AD9BD6611FD22D5D0907A85 /* ViewControllerWithLocalState.swift */,
 			);
-			name = ListScreen;
-			path = ListScreen;
+			name = TempuraTests;
+			path = TempuraTests;
 			sourceTree = "<group>";
 		};
-		F32B386625798C399D11202A /* UI */ = {
+		116470D3B6BC729821D9407D /* DemoTests */ = {
 			isa = PBXGroup;
 			children = (
-				F0E8F0D3793C9E7F19A742E7 /* ListScreen */,
-				6E5EFF7E2B5D7932A48A1C8B /* AddItemScreen */,
+				8976A233755FF97E27755795 /* DemoTests.swift */,
 			);
-			name = UI;
-			path = UI;
+			name = DemoTests;
+			path = DemoTests;
 			sourceTree = "<group>";
 		};
-		F63CD8C4427E8DA616894A90 /* Utilities */ = {
+		14531F76BC4BD9A3CCEF9BDB /* Resources */ = {
 			isa = PBXGroup;
 			children = (
-				F7368059D2F2383A9C8771B3 /* MainThread.swift */,
-			);
-			name = Utilities;
-			path = Utilities;
-			sourceTree = "<group>";
-		};
-		F7DAE5583A382B723D51F376 /* Actions */ = {
-			isa = PBXGroup;
-			children = (
-				B4D49F37A6EEB01D053F7784 /* AppActions.swift */,
-				60F537A90B62D747C9AA7A8E /* ItemActions.swift */,
-			);
-			name = Actions;
-			path = Actions;
-			sourceTree = "<group>";
-		};
-		FE04EC9E97818E31051F02B1 /* Resources */ = {
-			isa = PBXGroup;
-			children = (
-				7180309A39E4F8186CC96AB5 /* Media.xcassets */,
+				A7FF272B1D54329FB9BF586D /* Media.xcassets */,
 			);
 			name = Resources;
 			path = Resources;
 			sourceTree = "<group>";
 		};
+		336CA4D2C678EBD6C639755E /* Utilities */ = {
+			isa = PBXGroup;
+			children = (
+				703FB33C4C6E02B5CCD44130 /* MainThread.swift */,
+			);
+			name = Utilities;
+			path = Utilities;
+			sourceTree = "<group>";
+		};
+		492F9ECB515053E04BFE6E49 /* State */ = {
+			isa = PBXGroup;
+			children = (
+				43FC6AF877E3D1E1C573ED8E /* AppState.swift */,
+				93D4A1A478C64F8880867735 /* Models.swift */,
+			);
+			name = State;
+			path = State;
+			sourceTree = "<group>";
+		};
+		4C8E2228934980F0EA70FB6C /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				F39DA5D80D2669153AB5785D /* iOS */,
+				C9BA1DB585FEC92C018C563C /* Pods_DemoTests.framework */,
+				FD7E6BAC37BCB0CF99B72EFB /* Pods_Tempura.framework */,
+				014BB2A1BE317151FB012501 /* Pods_Tempura_Demo.framework */,
+				0C8A1111F4D42E83BDE6022D /* Pods_TempuraTesting.framework */,
+				48308C9CE5862566FB4A65E3 /* Pods_TempuraTests.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		544FFAC4903EF1FF36F72457 /* Utilities */ = {
+			isa = PBXGroup;
+			children = (
+				92E22D2E94CA28D6BCAE59F4 /* UIControl+TargetActionable.swift */,
+				B723380E4DB27859D4494A03 /* String+Random.swift */,
+				6FD9B1905F63029AA780A23F /* CollectionView */,
+				96800F24E222C6DB779D339E /* CGRect+Utils.swift */,
+				BF997DAF1E723495D9042F19 /* UIView+Blink.swift */,
+				AF31A3D61A640BF7BE456C7A /* String+Height.swift */,
+			);
+			name = Utilities;
+			path = Utilities;
+			sourceTree = "<group>";
+		};
+		6FD9B1905F63029AA780A23F /* CollectionView */ = {
+			isa = PBXGroup;
+			children = (
+				6F3396E6D30E2168C028BBC7 /* Source.swift */,
+				263FE4C84B71DD4E96506B71 /* CollectionView.swift */,
+				2B486EF6BA3C293C3AD8DA1A /* DataSource.swift */,
+				3A862F946946EC5123FEAA29 /* ConfigurableCell.swift */,
+			);
+			name = CollectionView;
+			path = CollectionView;
+			sourceTree = "<group>";
+		};
+		7D9E5217118E82BB7C529C95 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				E4F8CBDF73FA344BBF17B448 /* Pods-DemoTests.debug.xcconfig */,
+				6835FEE2AC44016AB6BB8B3B /* Pods-DemoTests.release.xcconfig */,
+				19ECEE9F71660063E140E9D8 /* Pods-Tempura.debug.xcconfig */,
+				87ED865E4F59019AC2D16CAC /* Pods-Tempura.release.xcconfig */,
+				ADD2E91D1642F6AC34DD5DA1 /* Pods-Tempura-Demo.debug.xcconfig */,
+				FA875DE51554C30103AD02D5 /* Pods-Tempura-Demo.release.xcconfig */,
+				896CD79E2C85799883633430 /* Pods-TempuraTesting.debug.xcconfig */,
+				4853973B62E0006AAE393402 /* Pods-TempuraTesting.release.xcconfig */,
+				235626D6A3B2F180FBA18922 /* Pods-TempuraTests.debug.xcconfig */,
+				1FBF9E1958499386813B3655 /* Pods-TempuraTests.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
+		846EC66D29E928BF2F6005FD /* Tempura */ = {
+			isa = PBXGroup;
+			children = (
+				BFF4DE430779D183D643E58C /* Core */,
+				E018A5BBFC7C894C11942844 /* Navigation */,
+				336CA4D2C678EBD6C639755E /* Utilities */,
+				C54AC073AD9E786DB1184238 /* UITests */,
+				0002B80022F240B2DFE7F7C9 /* SupportingFiles */,
+			);
+			name = Tempura;
+			path = Tempura;
+			sourceTree = "<group>";
+		};
+		8D0FAF2DCEE9D5DB27B98C49 /* Subviews */ = {
+			isa = PBXGroup;
+			children = (
+				B6F41B29DFC62B2985C10B45 /* ArchiveFlowLayout.swift */,
+				5ED21C2A91CCD05EF9E80453 /* TodoCell.swift */,
+				03BFCBB5A04BE02F87879EAC /* TodoFlowLayout.swift */,
+			);
+			name = Subviews;
+			path = Subviews;
+			sourceTree = "<group>";
+		};
+		97CB3272116B074BF6FBA3C0 /* UI */ = {
+			isa = PBXGroup;
+			children = (
+				C0CEC2A5864758B2C36CEC69 /* ListScreen */,
+				E66D185CDBAF81612A7265C7 /* AddItemScreen */,
+			);
+			name = UI;
+			path = UI;
+			sourceTree = "<group>";
+		};
+		B5FC027E4B3B32C1CFA818EC /* Subviews */ = {
+			isa = PBXGroup;
+			children = (
+				32CBB43468E3367CB492834E /* TextView.swift */,
+			);
+			name = Subviews;
+			path = Subviews;
+			sourceTree = "<group>";
+		};
+		BFF4DE430779D183D643E58C /* Core */ = {
+			isa = PBXGroup;
+			children = (
+				47E6CF03C58E0FDB7E111C2C /* ViewController.swift */,
+				DDBA2BEFFB6A124F1CC03D3B /* View.swift */,
+				0B80B19F0993FF6C18665C70 /* ViewModelWithState.swift */,
+				B08F0E49B2120828BF14CBF5 /* ModellableView.swift */,
+				5B8F1BC0D3FBA46773525E84 /* ViewModelWithLocalState.swift */,
+				046D0F45CAF4C076B44378FC /* LocalState.swift */,
+				5933E321276871DCE3DA1EB5 /* ViewModel.swift */,
+				02374EEF02DDFF5AA0F61E37 /* ViewControllerModellableView.swift */,
+				D9B2CE9D5CC2452E7F3F8FE4 /* ViewControllerWithLocalState.swift */,
+			);
+			name = Core;
+			path = Core;
+			sourceTree = "<group>";
+		};
+		C0CEC2A5864758B2C36CEC69 /* ListScreen */ = {
+			isa = PBXGroup;
+			children = (
+				C74D89702FC5977AD46F8625 /* ListViewController.swift */,
+				CAC627CE5B1C6444844358AA /* ListView.swift */,
+				8D0FAF2DCEE9D5DB27B98C49 /* Subviews */,
+			);
+			name = ListScreen;
+			path = ListScreen;
+			sourceTree = "<group>";
+		};
+		C54AC073AD9E786DB1184238 /* UITests */ = {
+			isa = PBXGroup;
+			children = (
+				411892F6257A13075A6DE9D3 /* UITests.swift */,
+				9616C4802BAEBA68CFFBF6C1 /* AsyncUITest.swift */,
+				7619E7499D0198D451B727E8 /* LocalFileURLProtocol.swift */,
+				C74B35841C695FE369AA61B9 /* UIView+snapshot.swift */,
+			);
+			name = UITests;
+			path = UITests;
+			sourceTree = "<group>";
+		};
+		D1EE42A348DABDA92B46D5E5 /* Demo */ = {
+			isa = PBXGroup;
+			children = (
+				97CB3272116B074BF6FBA3C0 /* UI */,
+				06951BFB6A8F7F8F2C547CAB /* Navigation */,
+				D72D6E4DDBCFB1FDC1078793 /* Dependencies */,
+				492F9ECB515053E04BFE6E49 /* State */,
+				544FFAC4903EF1FF36F72457 /* Utilities */,
+				DCD642263F580B537BEED972 /* Actions */,
+				F7A9D2BCE52DFE65639E24B8 /* Application */,
+				14531F76BC4BD9A3CCEF9BDB /* Resources */,
+			);
+			name = Demo;
+			path = Demo;
+			sourceTree = "<group>";
+		};
+		D72D6E4DDBCFB1FDC1078793 /* Dependencies */ = {
+			isa = PBXGroup;
+			children = (
+				D267050F2759FB614643A1CA /* DependenciesContainer.swift */,
+			);
+			name = Dependencies;
+			path = Dependencies;
+			sourceTree = "<group>";
+		};
+		DCD642263F580B537BEED972 /* Actions */ = {
+			isa = PBXGroup;
+			children = (
+				4E5EE7D9D5C149DED30D3122 /* AppActions.swift */,
+				5C4E326A4ABFA4C47965B9BF /* ItemActions.swift */,
+			);
+			name = Actions;
+			path = Actions;
+			sourceTree = "<group>";
+		};
+		E018A5BBFC7C894C11942844 /* Navigation */ = {
+			isa = PBXGroup;
+			children = (
+				26FCA6F0E4241D0FBA7AD8C9 /* NavigationActions.swift */,
+				A45E0875535580941275E976 /* NavigationUtilities.swift */,
+				D36EE94D33BF3422F158EF1C /* Routable.swift */,
+				4171BF68D9C8D22A5A4D1D79 /* RootInstaller.swift */,
+				B2207BA70818350B086E16C4 /* NavigationDSL.swift */,
+				361F637C9075217C1EA3C742 /* NavigationProvider.swift */,
+				CB23A93390A61F4B1578FD27 /* Navigator.swift */,
+			);
+			name = Navigation;
+			path = Navigation;
+			sourceTree = "<group>";
+		};
+		E66D185CDBAF81612A7265C7 /* AddItemScreen */ = {
+			isa = PBXGroup;
+			children = (
+				B5FC027E4B3B32C1CFA818EC /* Subviews */,
+				4B1A1E37A368ED70225277D6 /* AddItemView.swift */,
+				436316A65E092D4E747F4B23 /* AddItemViewController.swift */,
+			);
+			name = AddItemScreen;
+			path = AddItemScreen;
+			sourceTree = "<group>";
+		};
+		EDDD0051979BFA3749525513 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				5DA715507108DB2672BBD42E /* TempuraTests.xctest */,
+				F1184881A6C5AA7E0CBA1142 /* Tempura.framework */,
+				968F894C2347D8661A4849EA /* TempuraTesting.framework */,
+				951F01D47E0B6B5304B54CFD /* DemoTests.xctest */,
+				49F235E83EED0D8146311428 /* Demo.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		F18FEED7027719C0A16114D9 = {
+			isa = PBXGroup;
+			children = (
+				EDDD0051979BFA3749525513 /* Products */,
+				4C8E2228934980F0EA70FB6C /* Frameworks */,
+				1086B828A155BE5C276DA9F0 /* TempuraTests */,
+				846EC66D29E928BF2F6005FD /* Tempura */,
+				116470D3B6BC729821D9407D /* DemoTests */,
+				D1EE42A348DABDA92B46D5E5 /* Demo */,
+				7D9E5217118E82BB7C529C95 /* Pods */,
+			);
+			sourceTree = "<group>";
+		};
+		F39DA5D80D2669153AB5785D /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				A068A7E777A32BE636AE96F7 /* Foundation.framework */,
+				D2B04E9E3A5DC3C1280EEF96 /* UIKit.framework */,
+			);
+			name = iOS;
+			sourceTree = "<group>";
+		};
+		F7A9D2BCE52DFE65639E24B8 /* Application */ = {
+			isa = PBXGroup;
+			children = (
+				C831BD0E4860F7AD933817DE /* AppDelegate.swift */,
+			);
+			name = Application;
+			path = Application;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
-		3AB6063D2D57C312B6D66DD9 /* Headers */ = {
+		1514C9605E610150D9BE6C35 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D8E6F8BBA85F35B1C82C1B5A /* Tempura.h in Headers */,
+				721B58555A7E0C2BDBBCA1DB /* Tempura.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		D51472DDC53E59E53263C4F1 /* Headers */ = {
+		7D06E26664231CC736BD0A4F /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				FC88BE45A001668088063460 /* Tempura.h in Headers */,
+				CFC994F1EF51845CDD36D199 /* Tempura.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		0C7439E922866219444DC052 /* Demo */ = {
+		0D68CD697B9345A6E48FAB47 /* TempuraTests */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = F3E138FDDDB1A8111A128A78 /* Build configuration list for PBXNativeTarget "Demo" */;
+			buildConfigurationList = 600C43DAA6A8DEE3077E0A02 /* Build configuration list for PBXNativeTarget "TempuraTests" */;
 			buildPhases = (
-				D543AE67D61A676997306826 /* [CP] Check Pods Manifest.lock */,
-				D9003A41BF6883F1D0436279 /* Frameworks */,
-				3BCC20A864D7952AEE9AFB9F /* Sources */,
-				B8C316475F5AE780FDA7C7AC /* Resources */,
-				1BCD2BC0C9DA36B85D250730 /* Lint */,
-				E1323D85E1B5BA374C2339B0 /* [CP] Embed Pods Frameworks */,
+				E590B8C5208B354C0FF8D05A /* [CP] Check Pods Manifest.lock */,
+				04F36E965BE36422FC8B2601 /* Frameworks */,
+				C13EB658F19DCD63E949B584 /* Sources */,
+				A6BBE169B517CC3C84598138 /* Lint */,
+				E531AE0FB37D93C0AA912912 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				2C42B3338AC11A34594AF2AA /* PBXTargetDependency */,
+				EA3193BAF4ED38EB618E2F70 /* PBXTargetDependency */,
 			);
-			name = Demo;
-			productName = Demo;
-			productReference = B65B063D8BBBD5F462EDC289 /* Demo.app */;
-			productType = "com.apple.product-type.application";
+			name = TempuraTests;
+			productName = TempuraTests;
+			productReference = 5DA715507108DB2672BBD42E /* TempuraTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
 		};
-		2B6033DBD5E12ACC27453D7D /* TempuraTesting */ = {
+		515D36309BB1FA779E539C41 /* TempuraTesting */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 4A7F49F29772D002AA272D14 /* Build configuration list for PBXNativeTarget "TempuraTesting" */;
+			buildConfigurationList = D2FA2E89E35331B884DB529B /* Build configuration list for PBXNativeTarget "TempuraTesting" */;
 			buildPhases = (
-				2DE57398A6FDFF1C97D43F78 /* [CP] Check Pods Manifest.lock */,
-				8D92F13CAB5B6288279D7852 /* Frameworks */,
-				D894144104393C503D16D3CC /* Sources */,
-				D51472DDC53E59E53263C4F1 /* Headers */,
-				7EDD1D7B69ECE027BC15FC70 /* Lint */,
+				7512DF51172936C62584757D /* [CP] Check Pods Manifest.lock */,
+				216DBA50DEA3A4C632983D66 /* Frameworks */,
+				2E20795558A40337D15BD614 /* Sources */,
+				1514C9605E610150D9BE6C35 /* Headers */,
+				1B44D629F600413F882224AB /* Lint */,
 			);
 			buildRules = (
 			);
@@ -600,58 +599,18 @@
 			);
 			name = TempuraTesting;
 			productName = TempuraTesting;
-			productReference = 381FA20B59C6346F4DC398F8 /* TempuraTesting.framework */;
+			productReference = 968F894C2347D8661A4849EA /* TempuraTesting.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		345E0E905D3D50AD04EC672A /* DemoTests */ = {
+		68D33A3A28DA49773E5AC0DC /* Tempura */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 59F1A97EAADC2C3B7738C663 /* Build configuration list for PBXNativeTarget "DemoTests" */;
+			buildConfigurationList = 34C73837B24D2963DCB95C71 /* Build configuration list for PBXNativeTarget "Tempura" */;
 			buildPhases = (
-				6626FDB80A70A3037E7FCC02 /* [CP] Check Pods Manifest.lock */,
-				DE797355A59F33B9C584EC89 /* Frameworks */,
-				B34C1D6FAB423A3D2B56F2CA /* Sources */,
-				1FB0E8F284F64294E787C45D /* Lint */,
-				5732CAD453DA242B18E08CBD /* [CP] Embed Pods Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				CC38BC43D4FD85E0C1F78491 /* PBXTargetDependency */,
-			);
-			name = DemoTests;
-			productName = DemoTests;
-			productReference = 5A011D32DDB9A66339BB8328 /* DemoTests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
-		A40324486337B577624F7783 /* TempuraTests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = F2980363A15439246B5F15C5 /* Build configuration list for PBXNativeTarget "TempuraTests" */;
-			buildPhases = (
-				08B0B20D340F0DBD8C6E02E9 /* [CP] Check Pods Manifest.lock */,
-				4E9115B4CB89ADAC7933D3BE /* Frameworks */,
-				9B5891B3997A0BD2FDCE672B /* Sources */,
-				9E98237109BE42BD8A4192A2 /* Lint */,
-				55EB5B8938B397EAF872AF08 /* [CP] Embed Pods Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				84C0F51A3752AB2A08ED0144 /* PBXTargetDependency */,
-			);
-			name = TempuraTests;
-			productName = TempuraTests;
-			productReference = 6E8033671A8A7963E389304A /* TempuraTests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
-		FA1682828A9B8F1B00F69236 /* Tempura */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 0DED156F3643761C749FA709 /* Build configuration list for PBXNativeTarget "Tempura" */;
-			buildPhases = (
-				0FCEDC82D44D3D073643EF53 /* [CP] Check Pods Manifest.lock */,
-				D69D214182E648F5B316B8D8 /* Frameworks */,
-				BF41C3EF7E53E94335078632 /* Sources */,
-				3AB6063D2D57C312B6D66DD9 /* Headers */,
-				6C4DECCD6159853F6B05EA79 /* Lint */,
+				8FF7AC9CAEBE05D2EA89F3FA /* [CP] Check Pods Manifest.lock */,
+				7B087CACCEAE8EB6C0C8EE3F /* Frameworks */,
+				42A40141DE6418ADF0A6563A /* Sources */,
+				7D06E26664231CC736BD0A4F /* Headers */,
+				2B121A674330A04C156A9F7B /* Lint */,
 			);
 			buildRules = (
 			);
@@ -659,88 +618,93 @@
 			);
 			name = Tempura;
 			productName = Tempura;
-			productReference = 1C67EB1DECD1DC32B8FBC98F /* Tempura.framework */;
+			productReference = F1184881A6C5AA7E0CBA1142 /* Tempura.framework */;
 			productType = "com.apple.product-type.framework";
+		};
+		8FBDBA7D156E343288F8ED13 /* DemoTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B7E14A9432CE24D00B19E6D1 /* Build configuration list for PBXNativeTarget "DemoTests" */;
+			buildPhases = (
+				7F7846CDC7075B891F61F0BB /* [CP] Check Pods Manifest.lock */,
+				176B980F23E383060ECED5FA /* Frameworks */,
+				D5A3239AF0A65CA0D3A16F9B /* Sources */,
+				09DCB917CAACAAE9385D9507 /* Lint */,
+				EC8B4121E1DB17D3472FBABF /* [CP] Embed Pods Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				036028487A195C8EA4863EDC /* PBXTargetDependency */,
+			);
+			name = DemoTests;
+			productName = DemoTests;
+			productReference = 951F01D47E0B6B5304B54CFD /* DemoTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		E05343300C78F97F1748725A /* Demo */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 2E79223DA1D5ECB866C02FAD /* Build configuration list for PBXNativeTarget "Demo" */;
+			buildPhases = (
+				6B7F579C587EA78C80791F1B /* [CP] Check Pods Manifest.lock */,
+				2DB24F4575FABC05508E5289 /* Frameworks */,
+				EB43E91A1E6E2B3F64A6FE2E /* Sources */,
+				92D2905D98B0F00C107399E3 /* Resources */,
+				C6DDFCC04DE87E6581855498 /* Lint */,
+				BBDC63789838EDAE94D43864 /* [CP] Embed Pods Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				41F7FB71B6C78C7FFCCDAF68 /* PBXTargetDependency */,
+			);
+			name = Demo;
+			productName = Demo;
+			productReference = 49F235E83EED0D8146311428 /* Demo.app */;
+			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
-		744F8DC1C2ECD6BC4C6D9F61 /* Project object */ = {
+		21B81D37BB06880DEACF8ABF /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0930;
 				LastUpgradeCheck = 0930;
 			};
-			buildConfigurationList = 7E4345CCE8A0448446A9A313 /* Build configuration list for PBXProject "Tempura" */;
+			buildConfigurationList = 9895134E463DDA388559FBAE /* Build configuration list for PBXProject "Tempura" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
 			);
-			mainGroup = 90D89354CBF32246FC50B7ED;
-			productRefGroup = A63D8F9BDD9B3CD50F188017 /* Products */;
+			mainGroup = F18FEED7027719C0A16114D9;
+			productRefGroup = EDDD0051979BFA3749525513 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				A40324486337B577624F7783 /* TempuraTests */,
-				FA1682828A9B8F1B00F69236 /* Tempura */,
-				2B6033DBD5E12ACC27453D7D /* TempuraTesting */,
-				345E0E905D3D50AD04EC672A /* DemoTests */,
-				0C7439E922866219444DC052 /* Demo */,
+				0D68CD697B9345A6E48FAB47 /* TempuraTests */,
+				68D33A3A28DA49773E5AC0DC /* Tempura */,
+				515D36309BB1FA779E539C41 /* TempuraTesting */,
+				8FBDBA7D156E343288F8ED13 /* DemoTests */,
+				E05343300C78F97F1748725A /* Demo */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		B8C316475F5AE780FDA7C7AC /* Resources */ = {
+		92D2905D98B0F00C107399E3 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				91C62C450949534A2F7EA813 /* Media.xcassets in Resources */,
+				53457ECCD4BA391793A532A4 /* Media.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		08B0B20D340F0DBD8C6E02E9 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-TempuraTests-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		0FCEDC82D44D3D073643EF53 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-Tempura-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		1BCD2BC0C9DA36B85D250730 /* Lint */ = {
+		09DCB917CAACAAE9385D9507 /* Lint */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -755,7 +719,7 @@
 			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 			showEnvVarsInLog = 1;
 		};
-		1FB0E8F284F64294E787C45D /* Lint */ = {
+		1B44D629F600413F882224AB /* Lint */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -770,85 +734,7 @@
 			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 			showEnvVarsInLog = 1;
 		};
-		2DE57398A6FDFF1C97D43F78 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-TempuraTesting-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		55EB5B8938B397EAF872AF08 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-TempuraTests/Pods-TempuraTests-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/Nimble/Nimble.framework",
-				"${BUILT_PRODUCTS_DIR}/Quick/Quick.framework",
-				"${BUILT_PRODUCTS_DIR}/Katana/Katana.framework",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Nimble.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Quick.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Katana.framework",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-TempuraTests/Pods-TempuraTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		5732CAD453DA242B18E08CBD /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-DemoTests/Pods-DemoTests-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/Nimble/Nimble.framework",
-				"${BUILT_PRODUCTS_DIR}/Quick/Quick.framework",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Nimble.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Quick.framework",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-DemoTests/Pods-DemoTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		6626FDB80A70A3037E7FCC02 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-DemoTests-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		6C4DECCD6159853F6B05EA79 /* Lint */ = {
+		2B121A674330A04C156A9F7B /* Lint */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -863,37 +749,7 @@
 			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 			showEnvVarsInLog = 1;
 		};
-		7EDD1D7B69ECE027BC15FC70 /* Lint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = Lint;
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
-			showEnvVarsInLog = 1;
-		};
-		9E98237109BE42BD8A4192A2 /* Lint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = Lint;
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
-			showEnvVarsInLog = 1;
-		};
-		D543AE67D61A676997306826 /* [CP] Check Pods Manifest.lock */ = {
+		6B7F579C587EA78C80791F1B /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -911,7 +767,76 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		E1323D85E1B5BA374C2339B0 /* [CP] Embed Pods Frameworks */ = {
+		7512DF51172936C62584757D /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-TempuraTesting-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		7F7846CDC7075B891F61F0BB /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-DemoTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		8FF7AC9CAEBE05D2EA89F3FA /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Tempura-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		A6BBE169B517CC3C84598138 /* Lint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = Lint;
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			showEnvVarsInLog = 1;
+		};
+		BBDC63789838EDAE94D43864 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -933,136 +858,256 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Tempura-Demo/Pods-Tempura-Demo-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
+		C6DDFCC04DE87E6581855498 /* Lint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = Lint;
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			showEnvVarsInLog = 1;
+		};
+		E531AE0FB37D93C0AA912912 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${SRCROOT}/Pods/Target Support Files/Pods-TempuraTests/Pods-TempuraTests-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/Nimble/Nimble.framework",
+				"${BUILT_PRODUCTS_DIR}/Quick/Quick.framework",
+				"${BUILT_PRODUCTS_DIR}/Katana/Katana.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Nimble.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Quick.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Katana.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-TempuraTests/Pods-TempuraTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		E590B8C5208B354C0FF8D05A /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-TempuraTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		EC8B4121E1DB17D3472FBABF /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${SRCROOT}/Pods/Target Support Files/Pods-DemoTests/Pods-DemoTests-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/Nimble/Nimble.framework",
+				"${BUILT_PRODUCTS_DIR}/Quick/Quick.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Nimble.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Quick.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-DemoTests/Pods-DemoTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		3BCC20A864D7952AEE9AFB9F /* Sources */ = {
+		2E20795558A40337D15BD614 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				295C6ED37C94DB9D45C92D3A /* ListViewController.swift in Sources */,
-				35F06C66ECD30B414D0582F3 /* ListView.swift in Sources */,
-				B50FD728EB41C32748F05123 /* ArchiveFlowLayout.swift in Sources */,
-				3946C9CF0022A7679B5239BD /* TodoCell.swift in Sources */,
-				B71246BF4DB68D05BA3625FD /* TodoFlowLayout.swift in Sources */,
-				623CD15F07838DAADF036BE3 /* TextView.swift in Sources */,
-				08F25C6B8161D0978DDD56C4 /* AddItemView.swift in Sources */,
-				BFFD821875E2E6A2DF495026 /* AddItemViewController.swift in Sources */,
-				406D49FA794EF688698D8EA3 /* AppNavigation.swift in Sources */,
-				30B843FEDD9DCBEAF0E909EB /* DependenciesContainer.swift in Sources */,
-				CF1B6C43EBF075406B5195AC /* AppState.swift in Sources */,
-				A0B0822B065B0E94ABC3890F /* Models.swift in Sources */,
-				6A8B1A5C8CA4F6EC0DBD99E9 /* UIControl+TargetActionable.swift in Sources */,
-				1B40901ADAA3CF591F31D0A2 /* String+Random.swift in Sources */,
-				9A65E04602168AD6F273607C /* Source.swift in Sources */,
-				C72884173D9DF1921786A011 /* CollectionView.swift in Sources */,
-				1E61DD2B71E058CFA3534114 /* DataSource.swift in Sources */,
-				42222A378B10D633085E3E64 /* ConfigurableCell.swift in Sources */,
-				E0361285BDD779F39B07A93B /* CGRect+Utils.swift in Sources */,
-				C5EEE679D8F94F4778F956A2 /* UIView+Blink.swift in Sources */,
-				EA4C61EFB95CDB43A335CA19 /* String+Height.swift in Sources */,
-				9B3DF59E91CEC66D72808B13 /* AppActions.swift in Sources */,
-				F7C3D28120279CA681F8064A /* ItemActions.swift in Sources */,
-				E971CFC0889CC9BDAA96754C /* AppDelegate.swift in Sources */,
+				7587370463AC5DC6778B7E15 /* UITests.swift in Sources */,
+				CE61C7880E35F95676729DAD /* AsyncUITest.swift in Sources */,
+				44C79E4265260D9F72115CAA /* LocalFileURLProtocol.swift in Sources */,
+				78648662DB59EAB13ADA0ED6 /* UIView+snapshot.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		9B5891B3997A0BD2FDCE672B /* Sources */ = {
+		42A40141DE6418ADF0A6563A /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D91D1615297CFB528CAE190E /* ViewControllerSpec.swift in Sources */,
-				289620B3E828CDB63606753A /* ViewControllerWithLocalState.swift in Sources */,
+				3DE257E17D92AA9DB6787004 /* ViewController.swift in Sources */,
+				F9708DABDDFAE060D7367112 /* View.swift in Sources */,
+				973F983E0C5AF24F75709B4C /* ViewModelWithState.swift in Sources */,
+				0F83B97AF6431FA074B57C3C /* ModellableView.swift in Sources */,
+				4F6902ABCD4A7F4256870FE5 /* ViewModelWithLocalState.swift in Sources */,
+				9800AE746CA0B8FA80918051 /* LocalState.swift in Sources */,
+				DC0928F25485BC9B3DD23881 /* ViewModel.swift in Sources */,
+				8EFA54F1CDD0F371BCE7E3BF /* ViewControllerModellableView.swift in Sources */,
+				3CCFA32C7EE09408AD4FC2B2 /* ViewControllerWithLocalState.swift in Sources */,
+				9F4D41229A956E6C31D8E2F3 /* NavigationActions.swift in Sources */,
+				2C4816D452D501745D38E420 /* NavigationUtilities.swift in Sources */,
+				29A8CBD8C0B48086F9C63D1C /* Routable.swift in Sources */,
+				C121D1C4240BB081764B0C19 /* RootInstaller.swift in Sources */,
+				B3A632370BC5578F533D4440 /* NavigationDSL.swift in Sources */,
+				C01195CE453015E6D584BDC8 /* NavigationProvider.swift in Sources */,
+				A9ED186657C0EABBD4D53298 /* Navigator.swift in Sources */,
+				64D4F0C51044C5AA250502F1 /* MainThread.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		B34C1D6FAB423A3D2B56F2CA /* Sources */ = {
+		C13EB658F19DCD63E949B584 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C6D41F258158A8208015290F /* DemoTests.swift in Sources */,
+				5554244BA2E5BDEB707522A1 /* ViewControllerSpec.swift in Sources */,
+				FA3F30DF3B72E655E05D62B7 /* ViewControllerWithLocalState.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		BF41C3EF7E53E94335078632 /* Sources */ = {
+		D5A3239AF0A65CA0D3A16F9B /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9202EC82DED66B1E61F70AD4 /* ViewController.swift in Sources */,
-				F72D5F6CEBDC4FC36D80E47E /* View.swift in Sources */,
-				9EEBB05747812057F4E3C282 /* ViewModelWithState.swift in Sources */,
-				1DCBAFA218B5A12DBCA087C2 /* ModellableView.swift in Sources */,
-				7FD8052C66F108B5D6F4BC66 /* ViewModelWithLocalState.swift in Sources */,
-				DC5898710AC77ABF91A4BEFC /* LocalState.swift in Sources */,
-				F56B1FB4432EA880B3BCACB2 /* ViewModel.swift in Sources */,
-				5FC4802014383D7846F4FB39 /* ViewControllerModellableView.swift in Sources */,
-				3DEC2F7C8EF92B812B4A5ECD /* ViewControllerWithLocalState.swift in Sources */,
-				FA16FA60ACE255F8A17B22FA /* NavigationActions.swift in Sources */,
-				33CD89A43B08C0F440EF41F8 /* NavigationUtilities.swift in Sources */,
-				64BD1A49443C630F6E52FA7D /* Routable.swift in Sources */,
-				725063F64140B577096B12E6 /* RootInstaller.swift in Sources */,
-				0BC07B9E89823ACA783B29B5 /* NavigationDSL.swift in Sources */,
-				E45D168B17CE1F24987002E9 /* NavigationProvider.swift in Sources */,
-				7C59C9EFAA5918705515D3F4 /* Navigator.swift in Sources */,
-				7DE6B38DB208E665B6091579 /* MainThread.swift in Sources */,
+				265217387F567F42CD2FDC91 /* DemoTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		D894144104393C503D16D3CC /* Sources */ = {
+		EB43E91A1E6E2B3F64A6FE2E /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				78FDC854059BAB970749BF4E /* UITests.swift in Sources */,
-				9803B7C48C37CBBB082FFFD0 /* AsyncUITest.swift in Sources */,
-				3A709D65BA96CBEE35F0DF2A /* LocalFileURLProtocol.swift in Sources */,
-				D18D4A5891C020E574162675 /* UIView+snapshot.swift in Sources */,
+				E0113A5B1FF0F1242EFB2EDD /* ListViewController.swift in Sources */,
+				A89349BB2D1969598942BC53 /* ListView.swift in Sources */,
+				00E4A160141422D409F4D08E /* ArchiveFlowLayout.swift in Sources */,
+				B12D764A3DC40C34A6307AF8 /* TodoCell.swift in Sources */,
+				E23BB6BF7C80F05FB709FAD4 /* TodoFlowLayout.swift in Sources */,
+				07F766AFC906D61CA38A6759 /* TextView.swift in Sources */,
+				B7CDF2C0714B0D85325230D8 /* AddItemView.swift in Sources */,
+				0958975565897918175D5171 /* AddItemViewController.swift in Sources */,
+				538A8AEB23552A33DEF9C4D1 /* AppNavigation.swift in Sources */,
+				C370C0B66F3390BA57B28586 /* DependenciesContainer.swift in Sources */,
+				74F3EEC13FD7FA9028A44E5D /* AppState.swift in Sources */,
+				4DBA4F1D52371F75AC3A3453 /* Models.swift in Sources */,
+				AEB74A4AF22277D14C039AB6 /* UIControl+TargetActionable.swift in Sources */,
+				637E9C11E350B9F18119B158 /* String+Random.swift in Sources */,
+				1D2A3735B4E8E55BE2A27857 /* Source.swift in Sources */,
+				48F91F7160C6E36F0184A368 /* CollectionView.swift in Sources */,
+				5BC6BBF5CAEB1CE3F0AB3535 /* DataSource.swift in Sources */,
+				8A6E57CE75D1ACB5C44704B9 /* ConfigurableCell.swift in Sources */,
+				9EAD87D72487FC7DA65B6A3F /* CGRect+Utils.swift in Sources */,
+				8D07082C4874B398BF39E5AA /* UIView+Blink.swift in Sources */,
+				BD50738222241CC702D98845 /* String+Height.swift in Sources */,
+				993223EF813A314DFFEA2D7E /* AppActions.swift in Sources */,
+				8D8685C328EFC424D283E421 /* ItemActions.swift in Sources */,
+				6A2A3BD02A52FC780CE2DC10 /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		2C42B3338AC11A34594AF2AA /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Tempura;
-			target = FA1682828A9B8F1B00F69236 /* Tempura */;
-			targetProxy = 9F7A192C14D6B8BC49B87A30 /* PBXContainerItemProxy */;
-		};
-		84C0F51A3752AB2A08ED0144 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Tempura;
-			target = FA1682828A9B8F1B00F69236 /* Tempura */;
-			targetProxy = 0EC67DAE2C4AC94C701AC8F7 /* PBXContainerItemProxy */;
-		};
-		CC38BC43D4FD85E0C1F78491 /* PBXTargetDependency */ = {
+		036028487A195C8EA4863EDC /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = Demo;
-			target = 0C7439E922866219444DC052 /* Demo */;
-			targetProxy = E5EA61DB471C25D14B38AD16 /* PBXContainerItemProxy */;
+			target = E05343300C78F97F1748725A /* Demo */;
+			targetProxy = D0BBFC0F4FD77E279E2AF790 /* PBXContainerItemProxy */;
+		};
+		41F7FB71B6C78C7FFCCDAF68 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Tempura;
+			target = 68D33A3A28DA49773E5AC0DC /* Tempura */;
+			targetProxy = A2213B5F162F3920DF7E7A00 /* PBXContainerItemProxy */;
+		};
+		EA3193BAF4ED38EB618E2F70 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Tempura;
+			target = 68D33A3A28DA49773E5AC0DC /* Tempura */;
+			targetProxy = BD40FFEE3DAB19A8158E1F1F /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		1AF4E0D505A8F5E5D7DCCD29 /* Release */ = {
+		20A8C7C922169A7750EF2B87 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 639591CE1428B88CD4B5B159 /* Pods-DemoTests.release.xcconfig */;
+			baseConfigurationReference = 4853973B62E0006AAE393402 /* Pods-TempuraTesting.release.xcconfig */;
 			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				INFOPLIST_FILE = DemoTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Lib/**",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				INFOPLIST_FILE = Tempura/SupportingFiles/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = TempuraTesting;
 				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 4.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Demo.app/Demo";
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
 			};
 			name = Release;
 		};
-		25801FC713BBE38395E1777C /* Debug */ = {
+		228338DA6C010A895754F787 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B49FFD6DE4EDCCE4123697EF /* Pods-TempuraTests.debug.xcconfig */;
+			baseConfigurationReference = 19ECEE9F71660063E140E9D8 /* Pods-Tempura.debug.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Lib/**",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				INFOPLIST_FILE = Tempura/SupportingFiles/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = Tempura;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		274BE78C496467025A6A0442 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 235626D6A3B2F180FBA18922 /* Pods-TempuraTests.debug.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				INFOPLIST_FILE = TempuraTests/Info.plist;
@@ -1075,9 +1120,57 @@
 			};
 			name = Debug;
 		};
-		3CA9BBE616D0DC8450239607 /* Release */ = {
+		2D7A76CA1C18A5C39B0B357D /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = FEFD4C1CFEFFA69152127667 /* Pods-Tempura-Demo.release.xcconfig */;
+			baseConfigurationReference = 87ED865E4F59019AC2D16CAC /* Pods-Tempura.release.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Lib/**",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				INFOPLIST_FILE = Tempura/SupportingFiles/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = Tempura;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		7B893521459407C6DE8798EC /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 6835FEE2AC44016AB6BB8B3B /* Pods-DemoTests.release.xcconfig */;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				INFOPLIST_FILE = DemoTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 4.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Demo.app/Demo";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		81788914A6AE06B186924667 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FA875DE51554C30103AD02D5 /* Pods-Tempura-Demo.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -1094,9 +1187,9 @@
 			};
 			name = Release;
 		};
-		7124714CA9A6FEDCC7536B32 /* Debug */ = {
+		8601133482D54D5FF2DF3189 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 672A284CF0A423F452DFB2DB /* Pods-Tempura-Demo.debug.xcconfig */;
+			baseConfigurationReference = ADD2E91D1642F6AC34DD5DA1 /* Pods-Tempura-Demo.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -1113,9 +1206,55 @@
 			};
 			name = Debug;
 		};
-		71F535622F3266B925E0AD07 /* Debug */ = {
+		8F5108D8BA7095435083A273 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 3BBE5AA2DB1AA57D18D4C3FE /* Pods-DemoTests.debug.xcconfig */;
+			baseConfigurationReference = 896CD79E2C85799883633430 /* Pods-TempuraTesting.debug.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Lib/**",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				INFOPLIST_FILE = Tempura/SupportingFiles/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = TempuraTesting;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		B40E15BD362EAD15D6AFA8BB /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1FBF9E1958499386813B3655 /* Pods-TempuraTests.release.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				INFOPLIST_FILE = TempuraTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 4.0;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		C1A79A61F6282B9CE3B8A296 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = E4F8CBDF73FA344BBF17B448 /* Pods-DemoTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -1130,131 +1269,56 @@
 			};
 			name = Debug;
 		};
-		A389E3DDBC6DFAD3465AB3CF /* Debug */ = {
+		DC4758286201BCA772585D84 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 9AFA6BB18AE2564A37890F83 /* Pods-Tempura.debug.xcconfig */;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/Lib/**",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				INFOPLIST_FILE = Tempura/SupportingFiles/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_NAME = Tempura;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		C14CDF0C8DDD2DB81EA3D565 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8FD4588D8F66A1888833E983 /* Pods-TempuraTesting.release.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/Lib/**",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				INFOPLIST_FILE = Tempura/SupportingFiles/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_NAME = TempuraTesting;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 4.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;
 		};
-		D5AA15E6033E891E827E1F5A /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 97435C6E6CCD57CBD2C3D060 /* Pods-Tempura.release.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/Lib/**",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				INFOPLIST_FILE = Tempura/SupportingFiles/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_NAME = Tempura;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 4.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		E86488015C348D3CC20C3B0C /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 09BD506EA6A14312C94320AF /* Pods-TempuraTesting.debug.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/Lib/**",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				INFOPLIST_FILE = Tempura/SupportingFiles/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_NAME = TempuraTesting;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		EAA41A1518DBA71EA4B5B202 /* Debug */ = {
+		F4A1333919D75378E79D5215 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -1310,128 +1374,64 @@
 			};
 			name = Debug;
 		};
-		EEAAB5B0C1159F5143F900B1 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_ANALYZER_NONNULL = YES;
-				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_ENABLE_OBJC_WEAK = YES;
-				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_COMMA = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INFINITE_RECURSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-				CLANG_WARN_STRICT_PROTOTYPES = YES;
-				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				ENABLE_NS_ASSERTIONS = NO;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu11;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-			};
-			name = Release;
-		};
-		F0CA3D13F45DCCCDAFCBEE0A /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6F51E193225CE2C0CC58D843 /* Pods-TempuraTests.release.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				INFOPLIST_FILE = TempuraTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				SDKROOT = iphoneos;
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 4.0;
-				VALIDATE_PRODUCT = YES;
-			};
-			name = Release;
-		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		0DED156F3643761C749FA709 /* Build configuration list for PBXNativeTarget "Tempura" */ = {
+		2E79223DA1D5ECB866C02FAD /* Build configuration list for PBXNativeTarget "Demo" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				A389E3DDBC6DFAD3465AB3CF /* Debug */,
-				D5AA15E6033E891E827E1F5A /* Release */,
+				8601133482D54D5FF2DF3189 /* Debug */,
+				81788914A6AE06B186924667 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		4A7F49F29772D002AA272D14 /* Build configuration list for PBXNativeTarget "TempuraTesting" */ = {
+		34C73837B24D2963DCB95C71 /* Build configuration list for PBXNativeTarget "Tempura" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				E86488015C348D3CC20C3B0C /* Debug */,
-				C14CDF0C8DDD2DB81EA3D565 /* Release */,
+				228338DA6C010A895754F787 /* Debug */,
+				2D7A76CA1C18A5C39B0B357D /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		59F1A97EAADC2C3B7738C663 /* Build configuration list for PBXNativeTarget "DemoTests" */ = {
+		600C43DAA6A8DEE3077E0A02 /* Build configuration list for PBXNativeTarget "TempuraTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				71F535622F3266B925E0AD07 /* Debug */,
-				1AF4E0D505A8F5E5D7DCCD29 /* Release */,
+				274BE78C496467025A6A0442 /* Debug */,
+				B40E15BD362EAD15D6AFA8BB /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		7E4345CCE8A0448446A9A313 /* Build configuration list for PBXProject "Tempura" */ = {
+		9895134E463DDA388559FBAE /* Build configuration list for PBXProject "Tempura" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				EAA41A1518DBA71EA4B5B202 /* Debug */,
-				EEAAB5B0C1159F5143F900B1 /* Release */,
+				F4A1333919D75378E79D5215 /* Debug */,
+				DC4758286201BCA772585D84 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		F2980363A15439246B5F15C5 /* Build configuration list for PBXNativeTarget "TempuraTests" */ = {
+		B7E14A9432CE24D00B19E6D1 /* Build configuration list for PBXNativeTarget "DemoTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				25801FC713BBE38395E1777C /* Debug */,
-				F0CA3D13F45DCCCDAFCBEE0A /* Release */,
+				C1A79A61F6282B9CE3B8A296 /* Debug */,
+				7B893521459407C6DE8798EC /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		F3E138FDDDB1A8111A128A78 /* Build configuration list for PBXNativeTarget "Demo" */ = {
+		D2FA2E89E35331B884DB529B /* Build configuration list for PBXNativeTarget "TempuraTesting" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				7124714CA9A6FEDCC7536B32 /* Debug */,
-				3CA9BBE616D0DC8450239607 /* Release */,
+				8F5108D8BA7095435083A273 /* Debug */,
+				20A8C7C922169A7750EF2B87 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};
-	rootObject = 744F8DC1C2ECD6BC4C6D9F61 /* Project object */;
+	rootObject = 21B81D37BB06880DEACF8ABF /* Project object */;
 }

--- a/Tempura.xcodeproj/xcshareddata/xcschemes/Demo.xcscheme
+++ b/Tempura.xcodeproj/xcshareddata/xcschemes/Demo.xcscheme
@@ -14,7 +14,7 @@
             buildForArchiving = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "0C7439E922866219444DC052"
+               BlueprintIdentifier = "E05343300C78F97F1748725A"
                BlueprintName = "Demo"
                ReferencedContainer = "container:Tempura.xcodeproj"
                BuildableName = "Demo.app">
@@ -28,7 +28,7 @@
             buildForArchiving = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "345E0E905D3D50AD04EC672A"
+               BlueprintIdentifier = "8FBDBA7D156E343288F8ED13"
                BlueprintName = "DemoTests"
                ReferencedContainer = "container:Tempura.xcodeproj"
                BuildableName = "DemoTests.xctest">
@@ -48,7 +48,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "345E0E905D3D50AD04EC672A"
+               BlueprintIdentifier = "8FBDBA7D156E343288F8ED13"
                BlueprintName = "DemoTests"
                ReferencedContainer = "container:Tempura.xcodeproj"
                BuildableName = "DemoTests.xctest">
@@ -72,7 +72,7 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "0C7439E922866219444DC052"
+            BlueprintIdentifier = "E05343300C78F97F1748725A"
             BlueprintName = "Demo"
             ReferencedContainer = "container:Tempura.xcodeproj"
             BuildableName = "Demo.app">
@@ -88,7 +88,7 @@
       <BuildableProductRunnable>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "0C7439E922866219444DC052"
+            BlueprintIdentifier = "E05343300C78F97F1748725A"
             BlueprintName = "Demo"
             ReferencedContainer = "container:Tempura.xcodeproj"
             BuildableName = "Demo.app">

--- a/Tempura.xcodeproj/xcshareddata/xcschemes/Tempura.xcscheme
+++ b/Tempura.xcodeproj/xcshareddata/xcschemes/Tempura.xcscheme
@@ -14,7 +14,7 @@
             buildForArchiving = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "FA1682828A9B8F1B00F69236"
+               BlueprintIdentifier = "68D33A3A28DA49773E5AC0DC"
                BlueprintName = "Tempura"
                ReferencedContainer = "container:Tempura.xcodeproj"
                BuildableName = "Tempura.framework">
@@ -28,7 +28,7 @@
             buildForArchiving = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "A40324486337B577624F7783"
+               BlueprintIdentifier = "0D68CD697B9345A6E48FAB47"
                BlueprintName = "TempuraTests"
                ReferencedContainer = "container:Tempura.xcodeproj"
                BuildableName = "TempuraTests.xctest">
@@ -48,7 +48,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "A40324486337B577624F7783"
+               BlueprintIdentifier = "0D68CD697B9345A6E48FAB47"
                BlueprintName = "TempuraTests"
                ReferencedContainer = "container:Tempura.xcodeproj"
                BuildableName = "TempuraTests.xctest">
@@ -72,7 +72,7 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "FA1682828A9B8F1B00F69236"
+            BlueprintIdentifier = "68D33A3A28DA49773E5AC0DC"
             BlueprintName = "Tempura"
             ReferencedContainer = "container:Tempura.xcodeproj"
             BuildableName = "Tempura.framework">
@@ -88,7 +88,7 @@
       <BuildableProductRunnable>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "FA1682828A9B8F1B00F69236"
+            BlueprintIdentifier = "68D33A3A28DA49773E5AC0DC"
             BlueprintName = "Tempura"
             ReferencedContainer = "container:Tempura.xcodeproj"
             BuildableName = "Tempura.framework">

--- a/Tempura.xcodeproj/xcshareddata/xcschemes/TempuraTesting.xcscheme
+++ b/Tempura.xcodeproj/xcshareddata/xcschemes/TempuraTesting.xcscheme
@@ -14,7 +14,7 @@
             buildForArchiving = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "2B6033DBD5E12ACC27453D7D"
+               BlueprintIdentifier = "515D36309BB1FA779E539C41"
                BlueprintName = "TempuraTesting"
                ReferencedContainer = "container:Tempura.xcodeproj"
                BuildableName = "TempuraTesting.framework">
@@ -46,7 +46,7 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "2B6033DBD5E12ACC27453D7D"
+            BlueprintIdentifier = "515D36309BB1FA779E539C41"
             BlueprintName = "TempuraTesting"
             ReferencedContainer = "container:Tempura.xcodeproj"
             BuildableName = "TempuraTesting.framework">
@@ -62,7 +62,7 @@
       <BuildableProductRunnable>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "2B6033DBD5E12ACC27453D7D"
+            BlueprintIdentifier = "515D36309BB1FA779E539C41"
             BlueprintName = "TempuraTesting"
             ReferencedContainer = "container:Tempura.xcodeproj"
             BuildableName = "TempuraTesting.framework">

--- a/Tempura/UITests/UITests.swift
+++ b/Tempura/UITests/UITests.swift
@@ -236,9 +236,11 @@ public enum UITests {
   }
   
   private static func saveImage(_ image: UIImage, description: String) {
-    guard let mainDirPath = Bundle.main.infoDictionary?["UI_TEST_DIR"] as? String else { fatalError("UI_TEST_DIR not defined in your info.plist") }
-    let languageCode = Locale.current.languageCode ?? ""
-    var dirPath = languageCode.isEmpty ? mainDirPath : "\(mainDirPath)/\(languageCode)"
+    guard var dirPath = Bundle.main.infoDictionary?["UI_TEST_DIR"] as? String else { fatalError("UI_TEST_DIR not defined in your info.plist") }
+    
+    if let languageCode = Locale.current.languageCode {
+      dirPath = dirPath.appending("/\(languageCode)/")
+    }
     let screenSize = UIScreen.main.bounds.size
     let screenSizeDescription: String = "\(min(screenSize.width, screenSize.height))x\(max(screenSize.width, screenSize.height)))"
     

--- a/Tempura/UITests/UITests.swift
+++ b/Tempura/UITests/UITests.swift
@@ -236,8 +236,9 @@ public enum UITests {
   }
   
   private static func saveImage(_ image: UIImage, description: String) {
-    guard var dirPath = Bundle.main.infoDictionary?["UI_TEST_DIR"] as? String else { fatalError("UI_TEST_DIR not defined in your info.plist") }
-    
+    guard let mainDirPath = Bundle.main.infoDictionary?["UI_TEST_DIR"] as? String else { fatalError("UI_TEST_DIR not defined in your info.plist") }
+    let languageCode = Locale.current.languageCode ?? ""
+    var dirPath = languageCode.isEmpty ? mainDirPath : "\(mainDirPath)/\(languageCode)"
     let screenSize = UIScreen.main.bounds.size
     let screenSizeDescription: String = "\(min(screenSize.width, screenSize.height))x\(max(screenSize.width, screenSize.height)))"
     

--- a/Tempura/UITests/UITests.swift
+++ b/Tempura/UITests/UITests.swift
@@ -242,7 +242,7 @@ public enum UITests {
       dirPath = dirPath.appending("/\(languageCode)/")
     }
     let screenSize = UIScreen.main.bounds.size
-    let screenSizeDescription: String = "\(min(screenSize.width, screenSize.height))x\(max(screenSize.width, screenSize.height)))"
+    let screenSizeDescription: String = "\(min(screenSize.width, screenSize.height))x\(max(screenSize.width, screenSize.height))"
     
     dirPath = dirPath.appending("/\(screenSizeDescription)/")
     


### PR DESCRIPTION
**Why**
Right now, if you want to run ui tests in different languages, using the switch `-testLanguage <iso639-1 code>`, the test will overwrite the previous screenshots because the folder created by `UI_TEST_DIR` does not consider the locale of the device.

**Changes**
No changes in the API

**Tasks**
* [ ] Add relevant tests, if needed
* [ ] Add documentation, if needed
* [X] Update README, if needed
* [ ] Ensure that the demo project works properly