### PR TITLE
Fix/uitests languages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.1
+* Fix UITests by using the `collatorIdentifier` instead of the `languageCode`
+
 ## 3.0.0
 * Use Katana 3.0
 * Add support for UITests with ViewController containment

--- a/Tempura.xcodeproj/project.pbxproj
+++ b/Tempura.xcodeproj/project.pbxproj
@@ -6,584 +6,604 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0767353C79D7B582D3C24434 /* ViewControllerWithLocalStateSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41F3A1E2FFCEA557EFF40AFE /* ViewControllerWithLocalStateSpec.swift */; };
-		09CB0E2CE34D361C4BDBE1C4 /* AddItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89B8682B1C1E53E94EEFFF4 /* AddItemView.swift */; };
-		0D2BB2198C5DA52E758A4104 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2B40249C7B193332F68143A8 /* Foundation.framework */; };
-		0E778DE27B394F39E3757B5A /* ViewControllerTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7B200791097BB41545D8DD1 /* ViewControllerTestCase.swift */; };
-		13CAE0C88EB5254F94A21463 /* TodoCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EB2461C3CB6CEABF6487C2F /* TodoCell.swift */; };
-		158697D77424E08A69FE8E3B /* String+Height.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43BBC4E6E77910DDA22D2396 /* String+Height.swift */; };
-		1A27F1A6EDEE5E2676C90B84 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EC4FF595E9DD93ACD20E1A47 /* UIKit.framework */; };
-		1B78170AE3AC599EC77903F4 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EC4FF595E9DD93ACD20E1A47 /* UIKit.framework */; };
-		249A651327AACCC8BAAF7AD0 /* NavigationDSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 330A0C888A22EBC87D208108 /* NavigationDSL.swift */; };
-		24C7830B83527540086D7463 /* NavigationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7D434D10AF762EB61D12A29 /* NavigationProvider.swift */; };
-		25D9DF6EE8708EF67CCAF182 /* LocalState.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0B331C6B27CEB00C4B08222 /* LocalState.swift */; };
-		28E8123E7229D20C30CF7AA0 /* Pods_Tempura.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 97A409F8A8616437EAFEFDB5 /* Pods_Tempura.framework */; };
-		322C48A936CD4FDC8D21FEAC /* NavigationUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = F27E9544DBE7E0841A269834 /* NavigationUtilities.swift */; };
-		3559EB204BCE49BADAAF335D /* ListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63ABB78F4C730E04BC0D5879 /* ListViewController.swift */; };
-		35A83C0BB92E608F0B4BD174 /* Routable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4271E6039B19CD3E4260229D /* Routable.swift */; };
-		35EBCCE2C134C09990DB4866 /* Pods_TempuraTesting.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4D37FE0AF03F8963BE1EB32 /* Pods_TempuraTesting.framework */; };
-		39EF3EBA72416D8B62C23286 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2B40249C7B193332F68143A8 /* Foundation.framework */; };
-		3D721DA4FF25018C0BFBD3BF /* ViewControlerContainmentSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B5479C45997116F10AA7034 /* ViewControlerContainmentSpec.swift */; };
-		3E627D12CEC07D27406B001E /* TextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55CBA9356D11CCBF01F1BC22 /* TextView.swift */; };
-		4301A67A8EEC0A23A715AB97 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EC4FF595E9DD93ACD20E1A47 /* UIKit.framework */; };
-		475ECDA278A66D5BF495AA2C /* Source.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84DE2790B6B62A63AB4F7EEA /* Source.swift */; };
-		4B502C344826317DA9E27131 /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11DC3CE0E33ACC768E677C8E /* Models.swift */; };
-		4BB37619133E8729BC2C041B /* AppNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21512E2B1F981D97F3E5BEE9 /* AppNavigation.swift */; };
-		4C46CB4B012429DF7A383272 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47B8BBFD20F844509AD3D58D /* AppDelegate.swift */; };
-		5020440EBB3E6ACC147BD22B /* Tempura.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D1D08F42324271456321C3F4 /* Tempura.framework */; };
-		5024AEDE648BAAE8DF843C9F /* Tempura.h in Headers */ = {isa = PBXBuildFile; fileRef = C6552B0282F2F50F927B9576 /* Tempura.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		502C84C9B3DBA6D29A6FDCA6 /* ViewController+Containment.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8272F5675DFEA1A2D594DCD /* ViewController+Containment.swift */; };
-		578F049AD24E5628AA63FCCB /* Pods_Tempura_Demo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0C9A9D0EFC270474B360DB65 /* Pods_Tempura_Demo.framework */; };
-		57AB216A1DBEF24454162144 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2B40249C7B193332F68143A8 /* Foundation.framework */; };
-		5ABC048564C5B122B6D09185 /* DependenciesContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F2CF8248FAAB6EE2E7FB7B2 /* DependenciesContainer.swift */; };
-		5C5BD175E44EA64100FC5855 /* Media.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A954CDB5CE5240D1A8315592 /* Media.xcassets */; };
-		66E611826169A1866B67B95B /* Pods_DemoTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E49CC2848F373C212BF122D3 /* Pods_DemoTests.framework */; };
-		671C982E40D18E57F395DDD9 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EC4FF595E9DD93ACD20E1A47 /* UIKit.framework */; };
-		680BCF772690C6137804B025 /* ViewControllerWithLocalState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4367F57FC3FB14BB9B47459F /* ViewControllerWithLocalState.swift */; };
-		6B9E8EA42A3D832F45DC547E /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB948D6B963FB87F19C68F41 /* AppState.swift */; };
-		6BBD0B7EB76AC938AB15361B /* String+Random.swift in Sources */ = {isa = PBXBuildFile; fileRef = 079A88D77FF14612D943B885 /* String+Random.swift */; };
-		76F03EDAC31AFCD914F76DC4 /* DataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51DFFBEA64C40AA99343A685 /* DataSource.swift */; };
-		7CD20FD1667FDB8EE0017DE7 /* ArchiveFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34B65B9780B983FBC5DE477D /* ArchiveFlowLayout.swift */; };
-		85558A12B9416CD5D78156C5 /* ViewControllerModellableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9D54B50DB4DB339D9E4BA6F /* ViewControllerModellableView.swift */; };
-		8B2FC280EFB4AE83905DB188 /* LocalFileURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A0E47BF42C7AC691CB6A22B /* LocalFileURLProtocol.swift */; };
-		989E727656B535A7871D5E09 /* DemoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B4BA4669CE544CF8FE9479C /* DemoTests.swift */; };
-		993ACA741AB63E778227FF39 /* AddItemViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B959B960427C20E13151E8D /* AddItemViewController.swift */; };
-		999234490DC4E673A7C70DBE /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7F42360E7A4C4D25FC54D08 /* ViewController.swift */; };
-		99969FB0412492F5077B102B /* ListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D32CA06672CAB8FBB9CC8F3 /* ListView.swift */; };
-		99C36F19AAB7E54421A8763B /* ViewModelWithLocalState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11D4264B39355FB9B1F949C1 /* ViewModelWithLocalState.swift */; };
-		9A3A51A45ABD9CE89AAAD6C6 /* ConfigurableCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3D39A6A39514DD1B8E365EF /* ConfigurableCell.swift */; };
-		9C5A1C8ECFFC9D9D08E16D55 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2B40249C7B193332F68143A8 /* Foundation.framework */; };
-		9D52A3A6FF1574FA2D621CD8 /* UIView+Blink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D140E8532E50C808494B057 /* UIView+Blink.swift */; };
-		9DFCC81B73EFBC37624D1D02 /* UITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64A7344866C0739081C40B9B /* UITests.swift */; };
-		9F1676087E053A10E938204A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2B40249C7B193332F68143A8 /* Foundation.framework */; };
-		BB44B0EC81A1E5D513946DE8 /* Navigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B98CD1656310C5E97D4A1933 /* Navigator.swift */; };
-		BFCFD974A95A26D93BE54E24 /* Demo.app in Frameworks */ = {isa = PBXBuildFile; fileRef = AC96F4939CA97B9ED72F17BE /* Demo.app */; };
-		C2F4EFFABFB80443DA05A435 /* CollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41773D18D67D678E2530BE9F /* CollectionView.swift */; };
-		C30B936D219CF71BA14045C8 /* UIControl+TargetActionable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22DB264CDDC7C9D87E12F2A4 /* UIControl+TargetActionable.swift */; };
-		C3CDFE70200644F3CF7DB1B8 /* ModellableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A54807F663CE64C9D4A9EDA /* ModellableView.swift */; };
-		C6CF7AB44CFA4B1CDC616686 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EC4FF595E9DD93ACD20E1A47 /* UIKit.framework */; };
-		CE92FDE1576ADE01EEC6EB52 /* ViewModelWithState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35161330B234330AF8EFB0E6 /* ViewModelWithState.swift */; };
-		CECD601EB2F0393A0FDF136C /* RootInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F7E4622F4CE9B66E371B880 /* RootInstaller.swift */; };
-		D2210FAE5324220A47E087D2 /* UINavigationController+Completion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ABB6E307337C77ADDD40459 /* UINavigationController+Completion.swift */; };
-		D46D3DFED8C0B22CDC19C676 /* Tempura.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D1D08F42324271456321C3F4 /* Tempura.framework */; };
-		D9F516B5314B0214EFC05B23 /* ViewControllerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C3131C72F53E293DF1CF9E1 /* ViewControllerSpec.swift */; };
-		DB3BF1119B5330196746B5D7 /* Tempura.h in Headers */ = {isa = PBXBuildFile; fileRef = C6552B0282F2F50F927B9576 /* Tempura.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E13A0C90D4640E18FF0880E2 /* TodoFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FE39095E37B7518C624487A /* TodoFlowLayout.swift */; };
-		E28B2B4AE3726FDDFC065A00 /* ViewTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67A9BD19EF710E76A4CFFB88 /* ViewTestCase.swift */; };
-		E6314C48918F9F9733FB5053 /* View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4D34FFB9E93D2DA4971B32 /* View.swift */; };
-		EE489ADED9E1B4F96E46179C /* Pods_TempuraTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 554AB613491A621B1666BF85 /* Pods_TempuraTests.framework */; };
-		F04DA01F951CE83C732B3FA9 /* MainThread.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67A0B764CA5BF395EDAC9212 /* MainThread.swift */; };
-		F14E2316F3F3926EA364BF07 /* CGRect+Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE9301E21DA3AC6EF45E1F2 /* CGRect+Utils.swift */; };
-		F5E29E23E087AC4FE3ADDC62 /* NavigationActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 838B3B3D466BD052D2269EF3 /* NavigationActions.swift */; };
-		F81A83A0017193192CC27BF7 /* ItemActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A12627673A09B7301F16045 /* ItemActions.swift */; };
-		F8F822E4B098F13F2DB5A578 /* ChildViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C44201FC1C9CCB88E3387C /* ChildViewController.swift */; };
-		FCDB38EA341BDA179DBC47AB /* UIView+snapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D9F7E75BDB69CB80ABA2CD1 /* UIView+snapshot.swift */; };
-		FE70E34725740D9E51229D2E /* ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC0F2C6348B79255C938A99D /* ViewModel.swift */; };
+		023B2E55EA6F6515CC09CA01 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96A6CC05E8285AA21146DEAE /* ViewController.swift */; };
+		0484D9573D34F36F564EC425 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E43DB659E379F5729409D912 /* UIKit.framework */; };
+		07F8945CE69C6688BB72ED64 /* ViewController+Containment.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6D941EC2B28B3DF24BE2DA7 /* ViewController+Containment.swift */; };
+		0A97DB1E29A6E85F5374431B /* String+Height.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79709A26C0AFFD460177F61D /* String+Height.swift */; };
+		1163C5E52A677CB22E5CD9A0 /* Routable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CB14A6143AF8C68717C6547 /* Routable.swift */; };
+		14274D8328FE809BBA2B57AB /* ChildViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC1FF2B72CD8C1E1153EABF /* ChildViewController.swift */; };
+		1852F2EA800B4FD27CCE41F7 /* UIView+snapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6309C0A04948CF4F6558610E /* UIView+snapshot.swift */; };
+		1A1F679F4B8385CBBD770ED8 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E43DB659E379F5729409D912 /* UIKit.framework */; };
+		1CD83C17A5732AD886C73736 /* CollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69648C2C887CB08D6C8E5DEB /* CollectionView.swift */; };
+		1E21668168EDE22906AE27F3 /* ListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF06D904D61E8F79D2CE701B /* ListView.swift */; };
+		1E370FD2B00374DFF537EBE4 /* DemoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E56131672949A5E6A5F26568 /* DemoTests.swift */; };
+		24EC50B5A1C823CC9FA9B434 /* UIControl+TargetActionable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D323EDE6866A4493CEC89C5 /* UIControl+TargetActionable.swift */; };
+		2536845090987BAFE69E3CCB /* Navigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15845DCA84EFF9B9C4C515FA /* Navigator.swift */; };
+		32C3A07F35512724AF62218E /* ViewControllerModellableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 999315553E964397ED05AEE1 /* ViewControllerModellableView.swift */; };
+		3382C1B92FFB58BEAEBF3052 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8ED439DDC27CB9D63A613D71 /* Foundation.framework */; };
+		3486EFF679DC63B0EB845AC2 /* DependenciesContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76C842886C413FFAA631C9C9 /* DependenciesContainer.swift */; };
+		37580751D4678B066DB74198 /* AddItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F32F4AD75AB05624472F8090 /* AddItemView.swift */; };
+		39BECB701C79C9275E7030FA /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8ED439DDC27CB9D63A613D71 /* Foundation.framework */; };
+		3A953447470C5D99A21FCDDB /* View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28EBC6770288BB8366FCE19B /* View.swift */; };
+		3D7350791FDE088C51F51EDE /* AddItemViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C0634F12379FE56504A25FC /* AddItemViewController.swift */; };
+		3D756AAB4D795A62E5E9F5C8 /* String+Random.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAF5914A1E24E29DC7ADB762 /* String+Random.swift */; };
+		3EEDFD19910FDA5D7DCED462 /* DataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 861F78CDB0E0FA02A5BA7691 /* DataSource.swift */; };
+		40A3D995F83CFBFA732D10A2 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E43DB659E379F5729409D912 /* UIKit.framework */; };
+		4341E878EE83314B6A801717 /* NavigationUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6E90E24791D765ABC6A9304 /* NavigationUtilities.swift */; };
+		54C5CF2D9601D836BE70F179 /* Source.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D0844AC741A14600301ED47 /* Source.swift */; };
+		58A6370A15C64FE1066CFF58 /* ItemActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53042F59CE32ECC119FAF909 /* ItemActions.swift */; };
+		5ACFDE17E50C0D454DFAEEB8 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8ED439DDC27CB9D63A613D71 /* Foundation.framework */; };
+		611893E6A50CE035458C1195 /* TodoFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AB5750F1A4A880B47437C44 /* TodoFlowLayout.swift */; };
+		674514354BCD474FB056CD0F /* NavigationDSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = F362CDEAFC138C7A5166E6DC /* NavigationDSL.swift */; };
+		6A93E67F344699072FC1AE55 /* TextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28B737B5B70FDD17638314C5 /* TextView.swift */; };
+		6EAD41FF1175686A52B7596F /* Tempura.h in Headers */ = {isa = PBXBuildFile; fileRef = 3DF156EAE0D0E2C168DCFCFF /* Tempura.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		72B721F2777B1888E4A0C3C2 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EA5181D0826F46CB268D150 /* AppDelegate.swift */; };
+		7B8D1B373BECFB4DF432719F /* MainThread.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B4646D714F6E6378254870 /* MainThread.swift */; };
+		7E56F8F16969F420D787F5EF /* ViewControllerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EB295B059A7B287CD0A8306 /* ViewControllerSpec.swift */; };
+		7F1B9EAE20E1E1086A01FDC6 /* Demo.app in Frameworks */ = {isa = PBXBuildFile; fileRef = BBAF44EF5056FE4C19A1C005 /* Demo.app */; };
+		7FBC815764A802E35B005833 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8ED439DDC27CB9D63A613D71 /* Foundation.framework */; };
+		82ABE1C79910F9AF15916514 /* Tempura.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6B4F156025BA73A727CD7649 /* Tempura.framework */; };
+		8C5F207EF9411D751B819A41 /* ListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A23BFF9E0A464F527CABB2D1 /* ListViewController.swift */; };
+		8CC02B8B1AC87705C6E98CC1 /* Tempura.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6B4F156025BA73A727CD7649 /* Tempura.framework */; };
+		8EBEDA303350F64E9A9C2C38 /* NavigationActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1524C0C061413DE048728473 /* NavigationActions.swift */; };
+		91F9C94224E0A41B70898416 /* ViewModelWithState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99C88D91408BA73F0A9D9A65 /* ViewModelWithState.swift */; };
+		91FB1141814BBCC3E041C440 /* Pods_Tempura_Demo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 311628FCA12D17378A9787AD /* Pods_Tempura_Demo.framework */; };
+		920B75CE180884361EFDF2D2 /* UIView+Blink.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFB837FED084E40C920D7756 /* UIView+Blink.swift */; };
+		942FDEF9F962A28778AA8537 /* ConfigurableCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35DA26AB3FECC432CA17A38F /* ConfigurableCell.swift */; };
+		9798EB7221816184440FB32F /* LocalState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D01B36BBEECC4649A0F53E0C /* LocalState.swift */; };
+		9C7F4113B320E72C925BED61 /* NavigationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7D38EC223120B703126148B /* NavigationProvider.swift */; };
+		9CB31AF8A7CFF3F7114E2949 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8ED439DDC27CB9D63A613D71 /* Foundation.framework */; };
+		9F9467DC10A1BAFA49E1BAF7 /* ViewControllerWithLocalStateSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9936772F838D8C2CCF89E18 /* ViewControllerWithLocalStateSpec.swift */; };
+		9FB943D10DA9F72577450A89 /* Tempura.h in Headers */ = {isa = PBXBuildFile; fileRef = 3DF156EAE0D0E2C168DCFCFF /* Tempura.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A143C4050EFC7B35BB935DE7 /* Pods_DemoTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A2CC6990EC4D4F3EC61E860E /* Pods_DemoTests.framework */; };
+		B068CE3700771C35ABC3ADEB /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E43DB659E379F5729409D912 /* UIKit.framework */; };
+		B11CFAAC64DCECCF8B1D6F72 /* Pods_TempuraTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 49BDDE26DB99898D8B804D5F /* Pods_TempuraTests.framework */; };
+		B3092829130D9DA2BF533282 /* Pods_Tempura.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FA645470A27E0EDB8F7113BF /* Pods_Tempura.framework */; };
+		BA084013FEEE77DF808AE57B /* ViewTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EC5DD5A23B7AD5BF59379F2 /* ViewTestCase.swift */; };
+		BFC55B9021B3EBC1BA1C8E2E /* Media.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8690B22B8A30F11D754CF49D /* Media.xcassets */; };
+		C0AF48F8A0304E779039A1C9 /* ViewModelWithLocalState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62E20284D2FED93ADDD2F4B3 /* ViewModelWithLocalState.swift */; };
+		C3B38CB3CECD8E4AA896D66D /* CGRect+Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC8A65A70B7F93DE5A407011 /* CGRect+Utils.swift */; };
+		C4BE4BF296AA49B2EA1CD7B5 /* ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE48490B7C7C57EFF623BEC1 /* ViewModel.swift */; };
+		CC62EE7384E4A52B69C7C078 /* ViewControllerWithLocalState.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA4A820D40CE870E01E7D32A /* ViewControllerWithLocalState.swift */; };
+		D2DE2B562687B35C904C0028 /* ArchiveFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F0B8F2C9EE5DF1A55AFA0AB /* ArchiveFlowLayout.swift */; };
+		D98BBD26A96F6564715F4FE6 /* Pods_TempuraTesting.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4221AD921D106737B87B0D37 /* Pods_TempuraTesting.framework */; };
+		E1A7747F0F7EA42D16E5FE4B /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53465F9B2EF3A6A3844F3A58 /* AppState.swift */; };
+		E2D53B45A5CDFAA6856CCBD2 /* RootInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CC4D976F22221713F918D45 /* RootInstaller.swift */; };
+		E85812746E8F505ACF6E0A79 /* AppNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6098E71BE49993C3DE533BDE /* AppNavigation.swift */; };
+		EA7CDA869947054BC9341697 /* UITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B853F191D2F8F178756D5872 /* UITests.swift */; };
+		F253D779F28B4A9A3B905CF3 /* ModellableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E96B410A6BEEC65A12B57DE3 /* ModellableView.swift */; };
+		F30A835FE4E0691E789AC66C /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = F862DED732ECA78FC2D30164 /* Models.swift */; };
+		F38B0513BF60D65E976FFE1C /* LocalFileURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = F28FA02304732AA37F696C3D /* LocalFileURLProtocol.swift */; };
+		F456C6A8343FD6DAD16F29E6 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E43DB659E379F5729409D912 /* UIKit.framework */; };
+		FB3EDB89F6BC0CA2B4287944 /* TodoCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7F9CD3F9A685E6FCBFB3C07 /* TodoCell.swift */; };
+		FBC676737718804E7F8580BD /* ViewControlerContainmentSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06F3D2BF8CE9A5F332179141 /* ViewControlerContainmentSpec.swift */; };
+		FE9490F117ECFA1719696264 /* UINavigationController+Completion.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9FF854EF08A21816E65A8C3 /* UINavigationController+Completion.swift */; };
+		FF7CA16B97C2BECE5ECB6506 /* ViewControllerTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 912923F64FAD71F5EFC86F70 /* ViewControllerTestCase.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		3CD6039341409C7CDE0388D2 /* PBXContainerItemProxy */ = {
+		8E27D9B525DC526CB4E7A278 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = A75C0FF9FEEE90909893A374 /* Project object */;
+			containerPortal = 101B4AB3F10B9E0B33650F69 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 0BB3B28BA7AF6FEA31555207;
+			remoteGlobalIDString = A1389E2C90FB274567EB00F7;
 			remoteInfo = Tempura;
 		};
-		42F44F9E1FA3CF92F01447F3 /* PBXContainerItemProxy */ = {
+		C92FC67FD9AEF081F464FF4A /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = A75C0FF9FEEE90909893A374 /* Project object */;
+			containerPortal = 101B4AB3F10B9E0B33650F69 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 0BB3B28BA7AF6FEA31555207;
-			remoteInfo = Tempura;
-		};
-		E909C03848D0B2F86C44B249 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = A75C0FF9FEEE90909893A374 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = B40897FF34B40A9453A704F4;
+			remoteGlobalIDString = CB464AD513E869DB4BE0BB84;
 			remoteInfo = Demo;
+		};
+		ED8AD01F9BFCAFA7002460A2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 101B4AB3F10B9E0B33650F69 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A1389E2C90FB274567EB00F7;
+			remoteInfo = Tempura;
 		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		079A88D77FF14612D943B885 /* String+Random.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "String+Random.swift"; sourceTree = "<group>"; };
-		0B959B960427C20E13151E8D /* AddItemViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AddItemViewController.swift; sourceTree = "<group>"; };
-		0C17ADD6BE8EC9F20CD38063 /* Pods-TempuraTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TempuraTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-TempuraTests/Pods-TempuraTests.release.xcconfig"; sourceTree = "<group>"; };
-		0C9A9D0EFC270474B360DB65 /* Pods_Tempura_Demo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Tempura_Demo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		0D9F7E75BDB69CB80ABA2CD1 /* UIView+snapshot.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "UIView+snapshot.swift"; sourceTree = "<group>"; };
-		11D4264B39355FB9B1F949C1 /* ViewModelWithLocalState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewModelWithLocalState.swift; sourceTree = "<group>"; };
-		11DC3CE0E33ACC768E677C8E /* Models.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Models.swift; sourceTree = "<group>"; };
-		1A54807F663CE64C9D4A9EDA /* ModellableView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ModellableView.swift; sourceTree = "<group>"; };
-		21512E2B1F981D97F3E5BEE9 /* AppNavigation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppNavigation.swift; sourceTree = "<group>"; };
-		22DB264CDDC7C9D87E12F2A4 /* UIControl+TargetActionable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "UIControl+TargetActionable.swift"; sourceTree = "<group>"; };
-		2B40249C7B193332F68143A8 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS11.3.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		2B4BA4669CE544CF8FE9479C /* DemoTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DemoTests.swift; sourceTree = "<group>"; };
-		2C4D34FFB9E93D2DA4971B32 /* View.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = View.swift; sourceTree = "<group>"; };
-		2D140E8532E50C808494B057 /* UIView+Blink.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "UIView+Blink.swift"; sourceTree = "<group>"; };
-		330A0C888A22EBC87D208108 /* NavigationDSL.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NavigationDSL.swift; sourceTree = "<group>"; };
-		34B65B9780B983FBC5DE477D /* ArchiveFlowLayout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ArchiveFlowLayout.swift; sourceTree = "<group>"; };
-		35161330B234330AF8EFB0E6 /* ViewModelWithState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewModelWithState.swift; sourceTree = "<group>"; };
-		3A0E47BF42C7AC691CB6A22B /* LocalFileURLProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LocalFileURLProtocol.swift; sourceTree = "<group>"; };
-		3EFDDD90C3FA3CCD520AFBC0 /* Pods-DemoTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DemoTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-DemoTests/Pods-DemoTests.release.xcconfig"; sourceTree = "<group>"; };
-		41773D18D67D678E2530BE9F /* CollectionView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CollectionView.swift; sourceTree = "<group>"; };
-		41F3A1E2FFCEA557EFF40AFE /* ViewControllerWithLocalStateSpec.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewControllerWithLocalStateSpec.swift; sourceTree = "<group>"; };
-		4271E6039B19CD3E4260229D /* Routable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Routable.swift; sourceTree = "<group>"; };
-		4367F57FC3FB14BB9B47459F /* ViewControllerWithLocalState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewControllerWithLocalState.swift; sourceTree = "<group>"; };
-		43BBC4E6E77910DDA22D2396 /* String+Height.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "String+Height.swift"; sourceTree = "<group>"; };
-		47B8BBFD20F844509AD3D58D /* AppDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		49C44201FC1C9CCB88E3387C /* ChildViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ChildViewController.swift; sourceTree = "<group>"; };
-		4F2CF8248FAAB6EE2E7FB7B2 /* DependenciesContainer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DependenciesContainer.swift; sourceTree = "<group>"; };
-		51DFFBEA64C40AA99343A685 /* DataSource.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DataSource.swift; sourceTree = "<group>"; };
-		554AB613491A621B1666BF85 /* Pods_TempuraTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TempuraTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		55CBA9356D11CCBF01F1BC22 /* TextView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TextView.swift; sourceTree = "<group>"; };
-		5C3131C72F53E293DF1CF9E1 /* ViewControllerSpec.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewControllerSpec.swift; sourceTree = "<group>"; };
-		5F45A41958B4430F3ACCBDB1 /* TempuraTesting.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TempuraTesting.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		6209D2F5A140161EC3954169 /* DemoTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DemoTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		63ABB78F4C730E04BC0D5879 /* ListViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ListViewController.swift; sourceTree = "<group>"; };
-		64A7344866C0739081C40B9B /* UITests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UITests.swift; sourceTree = "<group>"; };
-		67A0B764CA5BF395EDAC9212 /* MainThread.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MainThread.swift; sourceTree = "<group>"; };
-		67A9BD19EF710E76A4CFFB88 /* ViewTestCase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewTestCase.swift; sourceTree = "<group>"; };
-		6ABB6E307337C77ADDD40459 /* UINavigationController+Completion.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "UINavigationController+Completion.swift"; sourceTree = "<group>"; };
-		6D32CA06672CAB8FBB9CC8F3 /* ListView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ListView.swift; sourceTree = "<group>"; };
-		6DA6940A28CA669448815865 /* Pods-TempuraTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TempuraTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-TempuraTests/Pods-TempuraTests.debug.xcconfig"; sourceTree = "<group>"; };
-		6EB2461C3CB6CEABF6487C2F /* TodoCell.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TodoCell.swift; sourceTree = "<group>"; };
-		7603DC076EB3DA6CA2580F72 /* Pods-Tempura-Demo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tempura-Demo.release.xcconfig"; path = "Pods/Target Support Files/Pods-Tempura-Demo/Pods-Tempura-Demo.release.xcconfig"; sourceTree = "<group>"; };
-		838B3B3D466BD052D2269EF3 /* NavigationActions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NavigationActions.swift; sourceTree = "<group>"; };
-		84DE2790B6B62A63AB4F7EEA /* Source.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Source.swift; sourceTree = "<group>"; };
-		8B5479C45997116F10AA7034 /* ViewControlerContainmentSpec.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewControlerContainmentSpec.swift; sourceTree = "<group>"; };
-		8FE39095E37B7518C624487A /* TodoFlowLayout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TodoFlowLayout.swift; sourceTree = "<group>"; };
-		9227BEDCE271A1F7321C284B /* Pods-TempuraTesting.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TempuraTesting.release.xcconfig"; path = "Pods/Target Support Files/Pods-TempuraTesting/Pods-TempuraTesting.release.xcconfig"; sourceTree = "<group>"; };
-		97A409F8A8616437EAFEFDB5 /* Pods_Tempura.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Tempura.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		9A12627673A09B7301F16045 /* ItemActions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ItemActions.swift; sourceTree = "<group>"; };
-		9F7E4622F4CE9B66E371B880 /* RootInstaller.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RootInstaller.swift; sourceTree = "<group>"; };
-		A7B200791097BB41545D8DD1 /* ViewControllerTestCase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewControllerTestCase.swift; sourceTree = "<group>"; };
-		A7D434D10AF762EB61D12A29 /* NavigationProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NavigationProvider.swift; sourceTree = "<group>"; };
-		A954CDB5CE5240D1A8315592 /* Media.xcassets */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder.assetcatalog; path = Media.xcassets; sourceTree = "<group>"; };
-		AAA0176238B5AE3D13232386 /* Pods-DemoTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DemoTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-DemoTests/Pods-DemoTests.debug.xcconfig"; sourceTree = "<group>"; };
-		AB948D6B963FB87F19C68F41 /* AppState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
-		AC96F4939CA97B9ED72F17BE /* Demo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Demo.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		AE1DAFC1C3E18EBCF6C6D33E /* Pods-Tempura.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tempura.release.xcconfig"; path = "Pods/Target Support Files/Pods-Tempura/Pods-Tempura.release.xcconfig"; sourceTree = "<group>"; };
-		AF2D3A78299905F0BE23C86A /* Pods-Tempura-Demo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tempura-Demo.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Tempura-Demo/Pods-Tempura-Demo.debug.xcconfig"; sourceTree = "<group>"; };
-		B98CD1656310C5E97D4A1933 /* Navigator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Navigator.swift; sourceTree = "<group>"; };
-		BAE9301E21DA3AC6EF45E1F2 /* CGRect+Utils.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "CGRect+Utils.swift"; sourceTree = "<group>"; };
-		C6552B0282F2F50F927B9576 /* Tempura.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = Tempura.h; sourceTree = "<group>"; };
-		C89B8682B1C1E53E94EEFFF4 /* AddItemView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AddItemView.swift; sourceTree = "<group>"; };
-		CAF11EEAC5039103A7B60DB3 /* TempuraTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TempuraTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		D1D08F42324271456321C3F4 /* Tempura.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Tempura.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		D3D39A6A39514DD1B8E365EF /* ConfigurableCell.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConfigurableCell.swift; sourceTree = "<group>"; };
-		D4D37FE0AF03F8963BE1EB32 /* Pods_TempuraTesting.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TempuraTesting.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		D8272F5675DFEA1A2D594DCD /* ViewController+Containment.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ViewController+Containment.swift"; sourceTree = "<group>"; };
-		E0B331C6B27CEB00C4B08222 /* LocalState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LocalState.swift; sourceTree = "<group>"; };
-		E17A5C015B2119C6FCA17010 /* Pods-Tempura.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tempura.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Tempura/Pods-Tempura.debug.xcconfig"; sourceTree = "<group>"; };
-		E49CC2848F373C212BF122D3 /* Pods_DemoTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_DemoTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		E7F42360E7A4C4D25FC54D08 /* ViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
-		E9D54B50DB4DB339D9E4BA6F /* ViewControllerModellableView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewControllerModellableView.swift; sourceTree = "<group>"; };
-		EC0F2C6348B79255C938A99D /* ViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewModel.swift; sourceTree = "<group>"; };
-		EC4FF595E9DD93ACD20E1A47 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS11.3.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
-		F27E9544DBE7E0841A269834 /* NavigationUtilities.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NavigationUtilities.swift; sourceTree = "<group>"; };
-		F82EB8257C9C2A596D0FB19E /* Pods-TempuraTesting.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TempuraTesting.debug.xcconfig"; path = "Pods/Target Support Files/Pods-TempuraTesting/Pods-TempuraTesting.debug.xcconfig"; sourceTree = "<group>"; };
+		019A9101238E41C7E02B2199 /* TempuraTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TempuraTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		02648BE03503594F16E1BACF /* Pods-Tempura.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tempura.release.xcconfig"; path = "Pods/Target Support Files/Pods-Tempura/Pods-Tempura.release.xcconfig"; sourceTree = "<group>"; };
+		06F3D2BF8CE9A5F332179141 /* ViewControlerContainmentSpec.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewControlerContainmentSpec.swift; sourceTree = "<group>"; };
+		0F0B8F2C9EE5DF1A55AFA0AB /* ArchiveFlowLayout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ArchiveFlowLayout.swift; sourceTree = "<group>"; };
+		148A21A85DE121A9FD5AC103 /* DemoTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DemoTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		1524C0C061413DE048728473 /* NavigationActions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NavigationActions.swift; sourceTree = "<group>"; };
+		15845DCA84EFF9B9C4C515FA /* Navigator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Navigator.swift; sourceTree = "<group>"; };
+		16C40E6D80AA7E566F489B8F /* Pods-DemoTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DemoTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-DemoTests/Pods-DemoTests.debug.xcconfig"; sourceTree = "<group>"; };
+		189627DB71A20362FA1BF928 /* Pods-TempuraTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TempuraTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-TempuraTests/Pods-TempuraTests.debug.xcconfig"; sourceTree = "<group>"; };
+		1D0844AC741A14600301ED47 /* Source.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Source.swift; sourceTree = "<group>"; };
+		28B737B5B70FDD17638314C5 /* TextView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TextView.swift; sourceTree = "<group>"; };
+		28EBC6770288BB8366FCE19B /* View.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = View.swift; sourceTree = "<group>"; };
+		2C0634F12379FE56504A25FC /* AddItemViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AddItemViewController.swift; sourceTree = "<group>"; };
+		311628FCA12D17378A9787AD /* Pods_Tempura_Demo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Tempura_Demo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		35DA26AB3FECC432CA17A38F /* ConfigurableCell.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConfigurableCell.swift; sourceTree = "<group>"; };
+		394C8A329E3FAA10F9F84289 /* Pods-TempuraTesting.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TempuraTesting.debug.xcconfig"; path = "Pods/Target Support Files/Pods-TempuraTesting/Pods-TempuraTesting.debug.xcconfig"; sourceTree = "<group>"; };
+		3AB5750F1A4A880B47437C44 /* TodoFlowLayout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TodoFlowLayout.swift; sourceTree = "<group>"; };
+		3DF156EAE0D0E2C168DCFCFF /* Tempura.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = Tempura.h; sourceTree = "<group>"; };
+		4221AD921D106737B87B0D37 /* Pods_TempuraTesting.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TempuraTesting.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		49BDDE26DB99898D8B804D5F /* Pods_TempuraTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TempuraTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		4AC1FF2B72CD8C1E1153EABF /* ChildViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ChildViewController.swift; sourceTree = "<group>"; };
+		4EA5181D0826F46CB268D150 /* AppDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		5110CAB236448B4251605A4B /* Pods-Tempura.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tempura.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Tempura/Pods-Tempura.debug.xcconfig"; sourceTree = "<group>"; };
+		53042F59CE32ECC119FAF909 /* ItemActions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ItemActions.swift; sourceTree = "<group>"; };
+		53465F9B2EF3A6A3844F3A58 /* AppState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
+		6098E71BE49993C3DE533BDE /* AppNavigation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppNavigation.swift; sourceTree = "<group>"; };
+		62E20284D2FED93ADDD2F4B3 /* ViewModelWithLocalState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewModelWithLocalState.swift; sourceTree = "<group>"; };
+		6309C0A04948CF4F6558610E /* UIView+snapshot.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "UIView+snapshot.swift"; sourceTree = "<group>"; };
+		69648C2C887CB08D6C8E5DEB /* CollectionView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CollectionView.swift; sourceTree = "<group>"; };
+		6B4F156025BA73A727CD7649 /* Tempura.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Tempura.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		6CC4D976F22221713F918D45 /* RootInstaller.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RootInstaller.swift; sourceTree = "<group>"; };
+		6CF97798DD5CC9299245340B /* Pods-TempuraTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TempuraTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-TempuraTests/Pods-TempuraTests.release.xcconfig"; sourceTree = "<group>"; };
+		75BE789CC542C89BCA59BC4E /* Pods-Tempura-Demo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tempura-Demo.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Tempura-Demo/Pods-Tempura-Demo.debug.xcconfig"; sourceTree = "<group>"; };
+		76C842886C413FFAA631C9C9 /* DependenciesContainer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DependenciesContainer.swift; sourceTree = "<group>"; };
+		79709A26C0AFFD460177F61D /* String+Height.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "String+Height.swift"; sourceTree = "<group>"; };
+		7C7DC56CCC5BE14482AEE335 /* Pods-Tempura-Demo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tempura-Demo.release.xcconfig"; path = "Pods/Target Support Files/Pods-Tempura-Demo/Pods-Tempura-Demo.release.xcconfig"; sourceTree = "<group>"; };
+		7CB14A6143AF8C68717C6547 /* Routable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Routable.swift; sourceTree = "<group>"; };
+		7EB295B059A7B287CD0A8306 /* ViewControllerSpec.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewControllerSpec.swift; sourceTree = "<group>"; };
+		861F78CDB0E0FA02A5BA7691 /* DataSource.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DataSource.swift; sourceTree = "<group>"; };
+		8690B22B8A30F11D754CF49D /* Media.xcassets */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder.assetcatalog; path = Media.xcassets; sourceTree = "<group>"; };
+		8EC5DD5A23B7AD5BF59379F2 /* ViewTestCase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewTestCase.swift; sourceTree = "<group>"; };
+		8ED439DDC27CB9D63A613D71 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS11.3.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		912923F64FAD71F5EFC86F70 /* ViewControllerTestCase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewControllerTestCase.swift; sourceTree = "<group>"; };
+		96A6CC05E8285AA21146DEAE /* ViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		983B8A3CFB70568DA097AEF2 /* Pods-DemoTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DemoTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-DemoTests/Pods-DemoTests.release.xcconfig"; sourceTree = "<group>"; };
+		999315553E964397ED05AEE1 /* ViewControllerModellableView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewControllerModellableView.swift; sourceTree = "<group>"; };
+		99C88D91408BA73F0A9D9A65 /* ViewModelWithState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewModelWithState.swift; sourceTree = "<group>"; };
+		9D323EDE6866A4493CEC89C5 /* UIControl+TargetActionable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "UIControl+TargetActionable.swift"; sourceTree = "<group>"; };
+		A23BFF9E0A464F527CABB2D1 /* ListViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ListViewController.swift; sourceTree = "<group>"; };
+		A2CC6990EC4D4F3EC61E860E /* Pods_DemoTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_DemoTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		A7F9CD3F9A685E6FCBFB3C07 /* TodoCell.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TodoCell.swift; sourceTree = "<group>"; };
+		AA4A820D40CE870E01E7D32A /* ViewControllerWithLocalState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewControllerWithLocalState.swift; sourceTree = "<group>"; };
+		B6D941EC2B28B3DF24BE2DA7 /* ViewController+Containment.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ViewController+Containment.swift"; sourceTree = "<group>"; };
+		B6E90E24791D765ABC6A9304 /* NavigationUtilities.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NavigationUtilities.swift; sourceTree = "<group>"; };
+		B853F191D2F8F178756D5872 /* UITests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UITests.swift; sourceTree = "<group>"; };
+		BBAF44EF5056FE4C19A1C005 /* Demo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Demo.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		C31978FB6F338CDAB9A0D41D /* Pods-TempuraTesting.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TempuraTesting.release.xcconfig"; path = "Pods/Target Support Files/Pods-TempuraTesting/Pods-TempuraTesting.release.xcconfig"; sourceTree = "<group>"; };
+		C9936772F838D8C2CCF89E18 /* ViewControllerWithLocalStateSpec.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewControllerWithLocalStateSpec.swift; sourceTree = "<group>"; };
+		C9B4646D714F6E6378254870 /* MainThread.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MainThread.swift; sourceTree = "<group>"; };
+		CAF5914A1E24E29DC7ADB762 /* String+Random.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "String+Random.swift"; sourceTree = "<group>"; };
+		D01B36BBEECC4649A0F53E0C /* LocalState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LocalState.swift; sourceTree = "<group>"; };
+		DC8A65A70B7F93DE5A407011 /* CGRect+Utils.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "CGRect+Utils.swift"; sourceTree = "<group>"; };
+		DF06D904D61E8F79D2CE701B /* ListView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ListView.swift; sourceTree = "<group>"; };
+		E43DB659E379F5729409D912 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS11.3.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
+		E56131672949A5E6A5F26568 /* DemoTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DemoTests.swift; sourceTree = "<group>"; };
+		E96B410A6BEEC65A12B57DE3 /* ModellableView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ModellableView.swift; sourceTree = "<group>"; };
+		E9FF854EF08A21816E65A8C3 /* UINavigationController+Completion.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "UINavigationController+Completion.swift"; sourceTree = "<group>"; };
+		EE48490B7C7C57EFF623BEC1 /* ViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewModel.swift; sourceTree = "<group>"; };
+		F28FA02304732AA37F696C3D /* LocalFileURLProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LocalFileURLProtocol.swift; sourceTree = "<group>"; };
+		F32F4AD75AB05624472F8090 /* AddItemView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AddItemView.swift; sourceTree = "<group>"; };
+		F362CDEAFC138C7A5166E6DC /* NavigationDSL.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NavigationDSL.swift; sourceTree = "<group>"; };
+		F7D38EC223120B703126148B /* NavigationProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NavigationProvider.swift; sourceTree = "<group>"; };
+		F839B45D66A6F3EFBE759E52 /* TempuraTesting.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TempuraTesting.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		F862DED732ECA78FC2D30164 /* Models.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Models.swift; sourceTree = "<group>"; };
+		FA645470A27E0EDB8F7113BF /* Pods_Tempura.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Tempura.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		FFB837FED084E40C920D7756 /* UIView+Blink.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "UIView+Blink.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		11FA22B796A5B5ADA96D684F /* Frameworks */ = {
+		0E320C8BF4BFFAD23CA3C7C0 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5020440EBB3E6ACC147BD22B /* Tempura.framework in Frameworks */,
-				9C5A1C8ECFFC9D9D08E16D55 /* Foundation.framework in Frameworks */,
-				671C982E40D18E57F395DDD9 /* UIKit.framework in Frameworks */,
-				578F049AD24E5628AA63FCCB /* Pods_Tempura_Demo.framework in Frameworks */,
+				8CC02B8B1AC87705C6E98CC1 /* Tempura.framework in Frameworks */,
+				7FBC815764A802E35B005833 /* Foundation.framework in Frameworks */,
+				40A3D995F83CFBFA732D10A2 /* UIKit.framework in Frameworks */,
+				B11CFAAC64DCECCF8B1D6F72 /* Pods_TempuraTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		614EB96EFFC9829BC8BFC880 /* Frameworks */ = {
+		47B49AA89C20B00A6121F86C /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D46D3DFED8C0B22CDC19C676 /* Tempura.framework in Frameworks */,
-				57AB216A1DBEF24454162144 /* Foundation.framework in Frameworks */,
-				4301A67A8EEC0A23A715AB97 /* UIKit.framework in Frameworks */,
-				EE489ADED9E1B4F96E46179C /* Pods_TempuraTests.framework in Frameworks */,
+				7F1B9EAE20E1E1086A01FDC6 /* Demo.app in Frameworks */,
+				9CB31AF8A7CFF3F7114E2949 /* Foundation.framework in Frameworks */,
+				B068CE3700771C35ABC3ADEB /* UIKit.framework in Frameworks */,
+				A143C4050EFC7B35BB935DE7 /* Pods_DemoTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		74A72206AE743CD9BD9FB5F6 /* Frameworks */ = {
+		7D872CA8A98B731B8003DC59 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9F1676087E053A10E938204A /* Foundation.framework in Frameworks */,
-				C6CF7AB44CFA4B1CDC616686 /* UIKit.framework in Frameworks */,
-				28E8123E7229D20C30CF7AA0 /* Pods_Tempura.framework in Frameworks */,
+				39BECB701C79C9275E7030FA /* Foundation.framework in Frameworks */,
+				F456C6A8343FD6DAD16F29E6 /* UIKit.framework in Frameworks */,
+				B3092829130D9DA2BF533282 /* Pods_Tempura.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		D3070ACEFCB31D5FFF00B10F /* Frameworks */ = {
+		8C76C7B80081652FDBA9ED4F /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0D2BB2198C5DA52E758A4104 /* Foundation.framework in Frameworks */,
-				1B78170AE3AC599EC77903F4 /* UIKit.framework in Frameworks */,
-				35EBCCE2C134C09990DB4866 /* Pods_TempuraTesting.framework in Frameworks */,
+				5ACFDE17E50C0D454DFAEEB8 /* Foundation.framework in Frameworks */,
+				1A1F679F4B8385CBBD770ED8 /* UIKit.framework in Frameworks */,
+				D98BBD26A96F6564715F4FE6 /* Pods_TempuraTesting.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		FD1A935179710B837E43B4CC /* Frameworks */ = {
+		C9DEC27B6F1CFD98A6B977AA /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BFCFD974A95A26D93BE54E24 /* Demo.app in Frameworks */,
-				39EF3EBA72416D8B62C23286 /* Foundation.framework in Frameworks */,
-				1A27F1A6EDEE5E2676C90B84 /* UIKit.framework in Frameworks */,
-				66E611826169A1866B67B95B /* Pods_DemoTests.framework in Frameworks */,
+				82ABE1C79910F9AF15916514 /* Tempura.framework in Frameworks */,
+				3382C1B92FFB58BEAEBF3052 /* Foundation.framework in Frameworks */,
+				0484D9573D34F36F564EC425 /* UIKit.framework in Frameworks */,
+				91FB1141814BBCC3E041C440 /* Pods_Tempura_Demo.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		0107B7A636A19309A8137E28 /* Utilities */ = {
+		00CB2A53F60D4ADF3900DA2A /* Resources */ = {
 			isa = PBXGroup;
 			children = (
-				22DB264CDDC7C9D87E12F2A4 /* UIControl+TargetActionable.swift */,
-				079A88D77FF14612D943B885 /* String+Random.swift */,
-				9685799CF8343A0AA9522C00 /* CollectionView */,
-				BAE9301E21DA3AC6EF45E1F2 /* CGRect+Utils.swift */,
-				2D140E8532E50C808494B057 /* UIView+Blink.swift */,
-				43BBC4E6E77910DDA22D2396 /* String+Height.swift */,
-			);
-			name = Utilities;
-			path = Utilities;
-			sourceTree = "<group>";
-		};
-		09C0C1FEE59FFE2A63A081BA /* Demo */ = {
-			isa = PBXGroup;
-			children = (
-				75F5CA1CC504AAC39D8DD340 /* UI */,
-				41FE8B87DA187E1E4DF3C156 /* Navigation */,
-				2F3C7F17A5FBB2E1A3B702E7 /* Dependencies */,
-				D2B4BCA3F229111C2D849B96 /* State */,
-				0107B7A636A19309A8137E28 /* Utilities */,
-				193162ECF218482E1B25BB5F /* Actions */,
-				500DA71486703CFACB29BA27 /* Application */,
-				FB011B68D08A835CC1983F8F /* Resources */,
-			);
-			name = Demo;
-			path = Demo;
-			sourceTree = "<group>";
-		};
-		11C69289E57799D13A6DF112 /* Tempura */ = {
-			isa = PBXGroup;
-			children = (
-				73DA4674A87FF253CFFF40BA /* Core */,
-				87D56B12B80078EA8233BADE /* Navigation */,
-				337E57722BDB26D0B537B9F7 /* Utilities */,
-				2996465EF82B815BE472BD56 /* UITests */,
-				B5E51473E17069D120AFD257 /* SupportingFiles */,
-			);
-			name = Tempura;
-			path = Tempura;
-			sourceTree = "<group>";
-		};
-		193162ECF218482E1B25BB5F /* Actions */ = {
-			isa = PBXGroup;
-			children = (
-				9A12627673A09B7301F16045 /* ItemActions.swift */,
-			);
-			name = Actions;
-			path = Actions;
-			sourceTree = "<group>";
-		};
-		2996465EF82B815BE472BD56 /* UITests */ = {
-			isa = PBXGroup;
-			children = (
-				64A7344866C0739081C40B9B /* UITests.swift */,
-				3A0E47BF42C7AC691CB6A22B /* LocalFileURLProtocol.swift */,
-				0D9F7E75BDB69CB80ABA2CD1 /* UIView+snapshot.swift */,
-				67A9BD19EF710E76A4CFFB88 /* ViewTestCase.swift */,
-				A7B200791097BB41545D8DD1 /* ViewControllerTestCase.swift */,
-			);
-			name = UITests;
-			path = UITests;
-			sourceTree = "<group>";
-		};
-		2F3C7F17A5FBB2E1A3B702E7 /* Dependencies */ = {
-			isa = PBXGroup;
-			children = (
-				4F2CF8248FAAB6EE2E7FB7B2 /* DependenciesContainer.swift */,
-			);
-			name = Dependencies;
-			path = Dependencies;
-			sourceTree = "<group>";
-		};
-		337E57722BDB26D0B537B9F7 /* Utilities */ = {
-			isa = PBXGroup;
-			children = (
-				67A0B764CA5BF395EDAC9212 /* MainThread.swift */,
-			);
-			name = Utilities;
-			path = Utilities;
-			sourceTree = "<group>";
-		};
-		39E1CDC808C7513B47D78B2D /* Subviews */ = {
-			isa = PBXGroup;
-			children = (
-				34B65B9780B983FBC5DE477D /* ArchiveFlowLayout.swift */,
-				6EB2461C3CB6CEABF6487C2F /* TodoCell.swift */,
-				8FE39095E37B7518C624487A /* TodoFlowLayout.swift */,
-			);
-			name = Subviews;
-			path = Subviews;
-			sourceTree = "<group>";
-		};
-		41FE8B87DA187E1E4DF3C156 /* Navigation */ = {
-			isa = PBXGroup;
-			children = (
-				21512E2B1F981D97F3E5BEE9 /* AppNavigation.swift */,
-			);
-			name = Navigation;
-			path = Navigation;
-			sourceTree = "<group>";
-		};
-		500DA71486703CFACB29BA27 /* Application */ = {
-			isa = PBXGroup;
-			children = (
-				47B8BBFD20F844509AD3D58D /* AppDelegate.swift */,
-			);
-			name = Application;
-			path = Application;
-			sourceTree = "<group>";
-		};
-		55442B1C71603DA5141094B0 = {
-			isa = PBXGroup;
-			children = (
-				C4B6FE672A76193A75BF55D0 /* Products */,
-				FA2929FE09C90068A12204A6 /* Frameworks */,
-				DA8297A9C90B12B8BEAE3ACC /* TempuraTests */,
-				11C69289E57799D13A6DF112 /* Tempura */,
-				871A19A345D24B930493B9F1 /* DemoTests */,
-				09C0C1FEE59FFE2A63A081BA /* Demo */,
-				D484A09C22A887CDBAED4F5C /* Pods */,
-			);
-			sourceTree = "<group>";
-		};
-		56043B3FDDC7CE54D23D3F3B /* ListScreen */ = {
-			isa = PBXGroup;
-			children = (
-				63ABB78F4C730E04BC0D5879 /* ListViewController.swift */,
-				6D32CA06672CAB8FBB9CC8F3 /* ListView.swift */,
-				39E1CDC808C7513B47D78B2D /* Subviews */,
-				49C44201FC1C9CCB88E3387C /* ChildViewController.swift */,
-			);
-			name = ListScreen;
-			path = ListScreen;
-			sourceTree = "<group>";
-		};
-		5FF507270AA839A647B27FF0 /* Subviews */ = {
-			isa = PBXGroup;
-			children = (
-				55CBA9356D11CCBF01F1BC22 /* TextView.swift */,
-			);
-			name = Subviews;
-			path = Subviews;
-			sourceTree = "<group>";
-		};
-		73DA4674A87FF253CFFF40BA /* Core */ = {
-			isa = PBXGroup;
-			children = (
-				E7F42360E7A4C4D25FC54D08 /* ViewController.swift */,
-				2C4D34FFB9E93D2DA4971B32 /* View.swift */,
-				35161330B234330AF8EFB0E6 /* ViewModelWithState.swift */,
-				1A54807F663CE64C9D4A9EDA /* ModellableView.swift */,
-				11D4264B39355FB9B1F949C1 /* ViewModelWithLocalState.swift */,
-				E0B331C6B27CEB00C4B08222 /* LocalState.swift */,
-				EC0F2C6348B79255C938A99D /* ViewModel.swift */,
-				E9D54B50DB4DB339D9E4BA6F /* ViewControllerModellableView.swift */,
-				4367F57FC3FB14BB9B47459F /* ViewControllerWithLocalState.swift */,
-				D8272F5675DFEA1A2D594DCD /* ViewController+Containment.swift */,
-			);
-			name = Core;
-			path = Core;
-			sourceTree = "<group>";
-		};
-		75F5CA1CC504AAC39D8DD340 /* UI */ = {
-			isa = PBXGroup;
-			children = (
-				56043B3FDDC7CE54D23D3F3B /* ListScreen */,
-				BDE0F015EC876C4726185867 /* AddItemScreen */,
-			);
-			name = UI;
-			path = UI;
-			sourceTree = "<group>";
-		};
-		871A19A345D24B930493B9F1 /* DemoTests */ = {
-			isa = PBXGroup;
-			children = (
-				2B4BA4669CE544CF8FE9479C /* DemoTests.swift */,
-			);
-			name = DemoTests;
-			path = DemoTests;
-			sourceTree = "<group>";
-		};
-		87D56B12B80078EA8233BADE /* Navigation */ = {
-			isa = PBXGroup;
-			children = (
-				6ABB6E307337C77ADDD40459 /* UINavigationController+Completion.swift */,
-				838B3B3D466BD052D2269EF3 /* NavigationActions.swift */,
-				F27E9544DBE7E0841A269834 /* NavigationUtilities.swift */,
-				4271E6039B19CD3E4260229D /* Routable.swift */,
-				9F7E4622F4CE9B66E371B880 /* RootInstaller.swift */,
-				330A0C888A22EBC87D208108 /* NavigationDSL.swift */,
-				A7D434D10AF762EB61D12A29 /* NavigationProvider.swift */,
-				B98CD1656310C5E97D4A1933 /* Navigator.swift */,
-			);
-			name = Navigation;
-			path = Navigation;
-			sourceTree = "<group>";
-		};
-		881B5E0F1784D04B19D35F00 /* iOS */ = {
-			isa = PBXGroup;
-			children = (
-				2B40249C7B193332F68143A8 /* Foundation.framework */,
-				EC4FF595E9DD93ACD20E1A47 /* UIKit.framework */,
-			);
-			name = iOS;
-			sourceTree = "<group>";
-		};
-		9685799CF8343A0AA9522C00 /* CollectionView */ = {
-			isa = PBXGroup;
-			children = (
-				84DE2790B6B62A63AB4F7EEA /* Source.swift */,
-				41773D18D67D678E2530BE9F /* CollectionView.swift */,
-				51DFFBEA64C40AA99343A685 /* DataSource.swift */,
-				D3D39A6A39514DD1B8E365EF /* ConfigurableCell.swift */,
-			);
-			name = CollectionView;
-			path = CollectionView;
-			sourceTree = "<group>";
-		};
-		B5E51473E17069D120AFD257 /* SupportingFiles */ = {
-			isa = PBXGroup;
-			children = (
-				C6552B0282F2F50F927B9576 /* Tempura.h */,
-			);
-			name = SupportingFiles;
-			path = SupportingFiles;
-			sourceTree = "<group>";
-		};
-		BDE0F015EC876C4726185867 /* AddItemScreen */ = {
-			isa = PBXGroup;
-			children = (
-				5FF507270AA839A647B27FF0 /* Subviews */,
-				C89B8682B1C1E53E94EEFFF4 /* AddItemView.swift */,
-				0B959B960427C20E13151E8D /* AddItemViewController.swift */,
-			);
-			name = AddItemScreen;
-			path = AddItemScreen;
-			sourceTree = "<group>";
-		};
-		C4B6FE672A76193A75BF55D0 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				CAF11EEAC5039103A7B60DB3 /* TempuraTests.xctest */,
-				D1D08F42324271456321C3F4 /* Tempura.framework */,
-				5F45A41958B4430F3ACCBDB1 /* TempuraTesting.framework */,
-				6209D2F5A140161EC3954169 /* DemoTests.xctest */,
-				AC96F4939CA97B9ED72F17BE /* Demo.app */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		D2B4BCA3F229111C2D849B96 /* State */ = {
-			isa = PBXGroup;
-			children = (
-				AB948D6B963FB87F19C68F41 /* AppState.swift */,
-				11DC3CE0E33ACC768E677C8E /* Models.swift */,
-			);
-			name = State;
-			path = State;
-			sourceTree = "<group>";
-		};
-		D484A09C22A887CDBAED4F5C /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				AAA0176238B5AE3D13232386 /* Pods-DemoTests.debug.xcconfig */,
-				3EFDDD90C3FA3CCD520AFBC0 /* Pods-DemoTests.release.xcconfig */,
-				E17A5C015B2119C6FCA17010 /* Pods-Tempura.debug.xcconfig */,
-				AE1DAFC1C3E18EBCF6C6D33E /* Pods-Tempura.release.xcconfig */,
-				AF2D3A78299905F0BE23C86A /* Pods-Tempura-Demo.debug.xcconfig */,
-				7603DC076EB3DA6CA2580F72 /* Pods-Tempura-Demo.release.xcconfig */,
-				F82EB8257C9C2A596D0FB19E /* Pods-TempuraTesting.debug.xcconfig */,
-				9227BEDCE271A1F7321C284B /* Pods-TempuraTesting.release.xcconfig */,
-				6DA6940A28CA669448815865 /* Pods-TempuraTests.debug.xcconfig */,
-				0C17ADD6BE8EC9F20CD38063 /* Pods-TempuraTests.release.xcconfig */,
-			);
-			name = Pods;
-			sourceTree = "<group>";
-		};
-		DA8297A9C90B12B8BEAE3ACC /* TempuraTests */ = {
-			isa = PBXGroup;
-			children = (
-				5C3131C72F53E293DF1CF9E1 /* ViewControllerSpec.swift */,
-				41F3A1E2FFCEA557EFF40AFE /* ViewControllerWithLocalStateSpec.swift */,
-				8B5479C45997116F10AA7034 /* ViewControlerContainmentSpec.swift */,
-			);
-			name = TempuraTests;
-			path = TempuraTests;
-			sourceTree = "<group>";
-		};
-		FA2929FE09C90068A12204A6 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				881B5E0F1784D04B19D35F00 /* iOS */,
-				E49CC2848F373C212BF122D3 /* Pods_DemoTests.framework */,
-				97A409F8A8616437EAFEFDB5 /* Pods_Tempura.framework */,
-				0C9A9D0EFC270474B360DB65 /* Pods_Tempura_Demo.framework */,
-				D4D37FE0AF03F8963BE1EB32 /* Pods_TempuraTesting.framework */,
-				554AB613491A621B1666BF85 /* Pods_TempuraTests.framework */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		FB011B68D08A835CC1983F8F /* Resources */ = {
-			isa = PBXGroup;
-			children = (
-				A954CDB5CE5240D1A8315592 /* Media.xcassets */,
+				8690B22B8A30F11D754CF49D /* Media.xcassets */,
 			);
 			name = Resources;
 			path = Resources;
 			sourceTree = "<group>";
 		};
+		0796A5A8A341A80F295A8D77 /* ListScreen */ = {
+			isa = PBXGroup;
+			children = (
+				A23BFF9E0A464F527CABB2D1 /* ListViewController.swift */,
+				DF06D904D61E8F79D2CE701B /* ListView.swift */,
+				0DD478D2334161690E56AB44 /* Subviews */,
+				4AC1FF2B72CD8C1E1153EABF /* ChildViewController.swift */,
+			);
+			name = ListScreen;
+			path = ListScreen;
+			sourceTree = "<group>";
+		};
+		0DD478D2334161690E56AB44 /* Subviews */ = {
+			isa = PBXGroup;
+			children = (
+				0F0B8F2C9EE5DF1A55AFA0AB /* ArchiveFlowLayout.swift */,
+				A7F9CD3F9A685E6FCBFB3C07 /* TodoCell.swift */,
+				3AB5750F1A4A880B47437C44 /* TodoFlowLayout.swift */,
+			);
+			name = Subviews;
+			path = Subviews;
+			sourceTree = "<group>";
+		};
+		1A7605A028424AA10CDC4292 /* Application */ = {
+			isa = PBXGroup;
+			children = (
+				4EA5181D0826F46CB268D150 /* AppDelegate.swift */,
+			);
+			name = Application;
+			path = Application;
+			sourceTree = "<group>";
+		};
+		26A51FD85FAC68F764FC9A11 /* Dependencies */ = {
+			isa = PBXGroup;
+			children = (
+				76C842886C413FFAA631C9C9 /* DependenciesContainer.swift */,
+			);
+			name = Dependencies;
+			path = Dependencies;
+			sourceTree = "<group>";
+		};
+		31CC80ACBC23EFCCCB155E79 /* UI */ = {
+			isa = PBXGroup;
+			children = (
+				0796A5A8A341A80F295A8D77 /* ListScreen */,
+				CF6BDBECAC9D41C6A6E5EFED /* AddItemScreen */,
+			);
+			name = UI;
+			path = UI;
+			sourceTree = "<group>";
+		};
+		31FD9DADB0CFB45C4B082CCE /* TempuraTests */ = {
+			isa = PBXGroup;
+			children = (
+				7EB295B059A7B287CD0A8306 /* ViewControllerSpec.swift */,
+				C9936772F838D8C2CCF89E18 /* ViewControllerWithLocalStateSpec.swift */,
+				06F3D2BF8CE9A5F332179141 /* ViewControlerContainmentSpec.swift */,
+			);
+			name = TempuraTests;
+			path = TempuraTests;
+			sourceTree = "<group>";
+		};
+		3616B300F03154E59CB79148 /* Utilities */ = {
+			isa = PBXGroup;
+			children = (
+				9D323EDE6866A4493CEC89C5 /* UIControl+TargetActionable.swift */,
+				CAF5914A1E24E29DC7ADB762 /* String+Random.swift */,
+				A76C22218093C887390E8520 /* CollectionView */,
+				DC8A65A70B7F93DE5A407011 /* CGRect+Utils.swift */,
+				FFB837FED084E40C920D7756 /* UIView+Blink.swift */,
+				79709A26C0AFFD460177F61D /* String+Height.swift */,
+			);
+			name = Utilities;
+			path = Utilities;
+			sourceTree = "<group>";
+		};
+		38FD03BF6DBD685A88720CF1 /* DemoTests */ = {
+			isa = PBXGroup;
+			children = (
+				E56131672949A5E6A5F26568 /* DemoTests.swift */,
+			);
+			name = DemoTests;
+			path = DemoTests;
+			sourceTree = "<group>";
+		};
+		3C46FA4C6982E359C73FB89F /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				16C40E6D80AA7E566F489B8F /* Pods-DemoTests.debug.xcconfig */,
+				983B8A3CFB70568DA097AEF2 /* Pods-DemoTests.release.xcconfig */,
+				5110CAB236448B4251605A4B /* Pods-Tempura.debug.xcconfig */,
+				02648BE03503594F16E1BACF /* Pods-Tempura.release.xcconfig */,
+				75BE789CC542C89BCA59BC4E /* Pods-Tempura-Demo.debug.xcconfig */,
+				7C7DC56CCC5BE14482AEE335 /* Pods-Tempura-Demo.release.xcconfig */,
+				394C8A329E3FAA10F9F84289 /* Pods-TempuraTesting.debug.xcconfig */,
+				C31978FB6F338CDAB9A0D41D /* Pods-TempuraTesting.release.xcconfig */,
+				189627DB71A20362FA1BF928 /* Pods-TempuraTests.debug.xcconfig */,
+				6CF97798DD5CC9299245340B /* Pods-TempuraTests.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
+		4EC1C9B54D8C95261B138D9C /* Core */ = {
+			isa = PBXGroup;
+			children = (
+				96A6CC05E8285AA21146DEAE /* ViewController.swift */,
+				28EBC6770288BB8366FCE19B /* View.swift */,
+				99C88D91408BA73F0A9D9A65 /* ViewModelWithState.swift */,
+				E96B410A6BEEC65A12B57DE3 /* ModellableView.swift */,
+				62E20284D2FED93ADDD2F4B3 /* ViewModelWithLocalState.swift */,
+				D01B36BBEECC4649A0F53E0C /* LocalState.swift */,
+				EE48490B7C7C57EFF623BEC1 /* ViewModel.swift */,
+				999315553E964397ED05AEE1 /* ViewControllerModellableView.swift */,
+				AA4A820D40CE870E01E7D32A /* ViewControllerWithLocalState.swift */,
+				B6D941EC2B28B3DF24BE2DA7 /* ViewController+Containment.swift */,
+			);
+			name = Core;
+			path = Core;
+			sourceTree = "<group>";
+		};
+		5B763946694B569AB962A95A = {
+			isa = PBXGroup;
+			children = (
+				A816ADC248D7D449F68C1F04 /* Products */,
+				31FD9DADB0CFB45C4B082CCE /* TempuraTests */,
+				E78143DDD11CE0F27D2F94A4 /* Tempura */,
+				38FD03BF6DBD685A88720CF1 /* DemoTests */,
+				B697A404C5E0BF43CCD1F43A /* Demo */,
+				94430E8300B6A575B6EF6E71 /* Frameworks */,
+				3C46FA4C6982E359C73FB89F /* Pods */,
+			);
+			sourceTree = "<group>";
+		};
+		6303F669CD5C83019FB8CB84 /* UITests */ = {
+			isa = PBXGroup;
+			children = (
+				B853F191D2F8F178756D5872 /* UITests.swift */,
+				F28FA02304732AA37F696C3D /* LocalFileURLProtocol.swift */,
+				6309C0A04948CF4F6558610E /* UIView+snapshot.swift */,
+				8EC5DD5A23B7AD5BF59379F2 /* ViewTestCase.swift */,
+				912923F64FAD71F5EFC86F70 /* ViewControllerTestCase.swift */,
+			);
+			name = UITests;
+			path = UITests;
+			sourceTree = "<group>";
+		};
+		7EC09F32172116A68E7CF27E /* SupportingFiles */ = {
+			isa = PBXGroup;
+			children = (
+				3DF156EAE0D0E2C168DCFCFF /* Tempura.h */,
+			);
+			name = SupportingFiles;
+			path = SupportingFiles;
+			sourceTree = "<group>";
+		};
+		8A14859EE695F9D83BE93C96 /* Subviews */ = {
+			isa = PBXGroup;
+			children = (
+				28B737B5B70FDD17638314C5 /* TextView.swift */,
+			);
+			name = Subviews;
+			path = Subviews;
+			sourceTree = "<group>";
+		};
+		94430E8300B6A575B6EF6E71 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				CC049E9E1042BD29A2552ED7 /* iOS */,
+				A2CC6990EC4D4F3EC61E860E /* Pods_DemoTests.framework */,
+				FA645470A27E0EDB8F7113BF /* Pods_Tempura.framework */,
+				311628FCA12D17378A9787AD /* Pods_Tempura_Demo.framework */,
+				4221AD921D106737B87B0D37 /* Pods_TempuraTesting.framework */,
+				49BDDE26DB99898D8B804D5F /* Pods_TempuraTests.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		95CCBA36C6F81EF7D0437CB2 /* Navigation */ = {
+			isa = PBXGroup;
+			children = (
+				6098E71BE49993C3DE533BDE /* AppNavigation.swift */,
+			);
+			name = Navigation;
+			path = Navigation;
+			sourceTree = "<group>";
+		};
+		A76C22218093C887390E8520 /* CollectionView */ = {
+			isa = PBXGroup;
+			children = (
+				1D0844AC741A14600301ED47 /* Source.swift */,
+				69648C2C887CB08D6C8E5DEB /* CollectionView.swift */,
+				861F78CDB0E0FA02A5BA7691 /* DataSource.swift */,
+				35DA26AB3FECC432CA17A38F /* ConfigurableCell.swift */,
+			);
+			name = CollectionView;
+			path = CollectionView;
+			sourceTree = "<group>";
+		};
+		A816ADC248D7D449F68C1F04 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				019A9101238E41C7E02B2199 /* TempuraTests.xctest */,
+				6B4F156025BA73A727CD7649 /* Tempura.framework */,
+				F839B45D66A6F3EFBE759E52 /* TempuraTesting.framework */,
+				148A21A85DE121A9FD5AC103 /* DemoTests.xctest */,
+				BBAF44EF5056FE4C19A1C005 /* Demo.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		AE66E6700F70891AEEF9A605 /* Utilities */ = {
+			isa = PBXGroup;
+			children = (
+				C9B4646D714F6E6378254870 /* MainThread.swift */,
+			);
+			name = Utilities;
+			path = Utilities;
+			sourceTree = "<group>";
+		};
+		B697A404C5E0BF43CCD1F43A /* Demo */ = {
+			isa = PBXGroup;
+			children = (
+				31CC80ACBC23EFCCCB155E79 /* UI */,
+				95CCBA36C6F81EF7D0437CB2 /* Navigation */,
+				26A51FD85FAC68F764FC9A11 /* Dependencies */,
+				F125B02ABDDBD22A1A0DDB98 /* State */,
+				3616B300F03154E59CB79148 /* Utilities */,
+				C61CAD8A91A5366111E9C220 /* Actions */,
+				1A7605A028424AA10CDC4292 /* Application */,
+				00CB2A53F60D4ADF3900DA2A /* Resources */,
+			);
+			name = Demo;
+			path = Demo;
+			sourceTree = "<group>";
+		};
+		C61CAD8A91A5366111E9C220 /* Actions */ = {
+			isa = PBXGroup;
+			children = (
+				53042F59CE32ECC119FAF909 /* ItemActions.swift */,
+			);
+			name = Actions;
+			path = Actions;
+			sourceTree = "<group>";
+		};
+		CC049E9E1042BD29A2552ED7 /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				8ED439DDC27CB9D63A613D71 /* Foundation.framework */,
+				E43DB659E379F5729409D912 /* UIKit.framework */,
+			);
+			name = iOS;
+			sourceTree = "<group>";
+		};
+		CF6BDBECAC9D41C6A6E5EFED /* AddItemScreen */ = {
+			isa = PBXGroup;
+			children = (
+				8A14859EE695F9D83BE93C96 /* Subviews */,
+				F32F4AD75AB05624472F8090 /* AddItemView.swift */,
+				2C0634F12379FE56504A25FC /* AddItemViewController.swift */,
+			);
+			name = AddItemScreen;
+			path = AddItemScreen;
+			sourceTree = "<group>";
+		};
+		E78143DDD11CE0F27D2F94A4 /* Tempura */ = {
+			isa = PBXGroup;
+			children = (
+				4EC1C9B54D8C95261B138D9C /* Core */,
+				FAD928CC504F8A796530DC73 /* Navigation */,
+				AE66E6700F70891AEEF9A605 /* Utilities */,
+				6303F669CD5C83019FB8CB84 /* UITests */,
+				7EC09F32172116A68E7CF27E /* SupportingFiles */,
+			);
+			name = Tempura;
+			path = Tempura;
+			sourceTree = "<group>";
+		};
+		F125B02ABDDBD22A1A0DDB98 /* State */ = {
+			isa = PBXGroup;
+			children = (
+				53465F9B2EF3A6A3844F3A58 /* AppState.swift */,
+				F862DED732ECA78FC2D30164 /* Models.swift */,
+			);
+			name = State;
+			path = State;
+			sourceTree = "<group>";
+		};
+		FAD928CC504F8A796530DC73 /* Navigation */ = {
+			isa = PBXGroup;
+			children = (
+				E9FF854EF08A21816E65A8C3 /* UINavigationController+Completion.swift */,
+				1524C0C061413DE048728473 /* NavigationActions.swift */,
+				B6E90E24791D765ABC6A9304 /* NavigationUtilities.swift */,
+				7CB14A6143AF8C68717C6547 /* Routable.swift */,
+				6CC4D976F22221713F918D45 /* RootInstaller.swift */,
+				F362CDEAFC138C7A5166E6DC /* NavigationDSL.swift */,
+				F7D38EC223120B703126148B /* NavigationProvider.swift */,
+				15845DCA84EFF9B9C4C515FA /* Navigator.swift */,
+			);
+			name = Navigation;
+			path = Navigation;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
-		36D8D0A32DA3D30A9345E72D /* Headers */ = {
+		064FF6931C6F4F63FE1E426C /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5024AEDE648BAAE8DF843C9F /* Tempura.h in Headers */,
+				9FB943D10DA9F72577450A89 /* Tempura.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		3888949D40C705EA5C92D87B /* Headers */ = {
+		80EDD9B030EC08C34CF53A1D /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DB3BF1119B5330196746B5D7 /* Tempura.h in Headers */,
+				6EAD41FF1175686A52B7596F /* Tempura.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		0BB3B28BA7AF6FEA31555207 /* Tempura */ = {
+		463B08FD56F78F2D7F0904E9 /* DemoTests */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = CE0E8790398EDBBE82599B53 /* Build configuration list for PBXNativeTarget "Tempura" */;
+			buildConfigurationList = 68475462C31C9266B3CE2128 /* Build configuration list for PBXNativeTarget "DemoTests" */;
 			buildPhases = (
-				3251B7D49E0315B1514F6531 /* [CP] Check Pods Manifest.lock */,
-				74A72206AE743CD9BD9FB5F6 /* Frameworks */,
-				A7E54BF057BD82107244AF7C /* Sources */,
-				36D8D0A32DA3D30A9345E72D /* Headers */,
-				541EFF52C25D7B36CBBE5A64 /* Lint */,
+				2D81A6A6600E703655BDCA9F /* [CP] Check Pods Manifest.lock */,
+				47B49AA89C20B00A6121F86C /* Frameworks */,
+				015C79207B40F8D2EEFBCB72 /* Sources */,
+				B7E8C4A70B9C8DAE889BC83B /* Lint */,
+				C58BF76DA6DA09BB3463F7B7 /* [CP] Embed Pods Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				E54FD27DE6C478213BC5EBEE /* PBXTargetDependency */,
+			);
+			name = DemoTests;
+			productName = DemoTests;
+			productReference = 148A21A85DE121A9FD5AC103 /* DemoTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		A1389E2C90FB274567EB00F7 /* Tempura */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 636E5367004736B36D6066E4 /* Build configuration list for PBXNativeTarget "Tempura" */;
+			buildPhases = (
+				FF031E2C5E102AADE39A7FE2 /* [CP] Check Pods Manifest.lock */,
+				01C7C9CAB4634C33B19349F5 /* Sources */,
+				7D872CA8A98B731B8003DC59 /* Frameworks */,
+				064FF6931C6F4F63FE1E426C /* Headers */,
+				85A81723C2FE1F5A2AAFAB60 /* Lint */,
 			);
 			buildRules = (
 			);
@@ -591,38 +611,18 @@
 			);
 			name = Tempura;
 			productName = Tempura;
-			productReference = D1D08F42324271456321C3F4 /* Tempura.framework */;
+			productReference = 6B4F156025BA73A727CD7649 /* Tempura.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		5736D14703646BCA3EE58B2C /* TempuraTests */ = {
+		B437ED925E4B0FBC1C6DF63B /* TempuraTesting */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 3468A8E5D8C569DDB5FC51A6 /* Build configuration list for PBXNativeTarget "TempuraTests" */;
+			buildConfigurationList = D10317CDE194193B53048089 /* Build configuration list for PBXNativeTarget "TempuraTesting" */;
 			buildPhases = (
-				288B8B6DF1AA9EFA1CBD6E52 /* [CP] Check Pods Manifest.lock */,
-				614EB96EFFC9829BC8BFC880 /* Frameworks */,
-				B095848C621FB72FE5C6D319 /* Sources */,
-				BD8DFC249BA8B8AC77103D31 /* Lint */,
-				18F5ED8CEC8D7E175CA419E9 /* [CP] Embed Pods Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				E920D0835C736C8F8BFBA55A /* PBXTargetDependency */,
-			);
-			name = TempuraTests;
-			productName = TempuraTests;
-			productReference = CAF11EEAC5039103A7B60DB3 /* TempuraTests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
-		6B4B77B288AB120BB5FB608F /* TempuraTesting */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 683D8930F105AFFD4A370C14 /* Build configuration list for PBXNativeTarget "TempuraTesting" */;
-			buildPhases = (
-				DBE88299778FCB01ACDCD49D /* [CP] Check Pods Manifest.lock */,
-				D3070ACEFCB31D5FFF00B10F /* Frameworks */,
-				8A574182201A3EED822FC887 /* Sources */,
-				3888949D40C705EA5C92D87B /* Headers */,
-				68D3CD9B652F6A84D3785039 /* Lint */,
+				EE512BB7B33CE861B4B6BCB3 /* [CP] Check Pods Manifest.lock */,
+				D82D49D39A8D730457CC9584 /* Sources */,
+				8C76C7B80081652FDBA9ED4F /* Frameworks */,
+				80EDD9B030EC08C34CF53A1D /* Headers */,
+				BF74842AFCCD239C6B97D025 /* Lint */,
 			);
 			buildRules = (
 			);
@@ -630,140 +630,93 @@
 			);
 			name = TempuraTesting;
 			productName = TempuraTesting;
-			productReference = 5F45A41958B4430F3ACCBDB1 /* TempuraTesting.framework */;
+			productReference = F839B45D66A6F3EFBE759E52 /* TempuraTesting.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		94A12E8EFBA78087651A954C /* DemoTests */ = {
+		C48B2C6F37E2641AC90FD5BB /* TempuraTests */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = E4CD0F9FFEA41BAC718CCDA6 /* Build configuration list for PBXNativeTarget "DemoTests" */;
+			buildConfigurationList = ECB39273DF7F033DE9E4BF50 /* Build configuration list for PBXNativeTarget "TempuraTests" */;
 			buildPhases = (
-				AF01521B808FE1A25CFC1DA2 /* [CP] Check Pods Manifest.lock */,
-				FD1A935179710B837E43B4CC /* Frameworks */,
-				6F9F7153B3A5289839C9A8A6 /* Sources */,
-				1AA4F6B7B315CF4D099DA8CA /* Lint */,
-				4DBA9DFB9BE88A16CD18A67D /* [CP] Embed Pods Frameworks */,
+				F73A77013F77BF82737F6D21 /* [CP] Check Pods Manifest.lock */,
+				0E320C8BF4BFFAD23CA3C7C0 /* Frameworks */,
+				B495761916DA4A81B728CD58 /* Sources */,
+				B4C2B9901D84F7E913D0C701 /* Lint */,
+				CBAFC27696123FC96615F475 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				AB99E69902469ED6BC89CA1F /* PBXTargetDependency */,
+				F1436317566FD62CE02091AF /* PBXTargetDependency */,
 			);
-			name = DemoTests;
-			productName = DemoTests;
-			productReference = 6209D2F5A140161EC3954169 /* DemoTests.xctest */;
+			name = TempuraTests;
+			productName = TempuraTests;
+			productReference = 019A9101238E41C7E02B2199 /* TempuraTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
-		B40897FF34B40A9453A704F4 /* Demo */ = {
+		CB464AD513E869DB4BE0BB84 /* Demo */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = C314B63FAD28A3CCF5D166C0 /* Build configuration list for PBXNativeTarget "Demo" */;
+			buildConfigurationList = CE865A114656481F78AA7A53 /* Build configuration list for PBXNativeTarget "Demo" */;
 			buildPhases = (
-				49346C87DEFF3DF4D207C4C4 /* [CP] Check Pods Manifest.lock */,
-				11FA22B796A5B5ADA96D684F /* Frameworks */,
-				939F74F151489A95AA924EB9 /* Sources */,
-				6CA9B47936F5513E2E867F2F /* Resources */,
-				860E6F711D674ECFDF08898F /* Lint */,
-				986AA6BD69C29511870B0622 /* [CP] Embed Pods Frameworks */,
+				93A8CE45B35EDACC9AEB9BF3 /* [CP] Check Pods Manifest.lock */,
+				C9DEC27B6F1CFD98A6B977AA /* Frameworks */,
+				6E5F054AAB054A4D8DD8F99D /* Sources */,
+				20F7941CC56B714AE849116C /* Resources */,
+				BFECF1A531576FC5E227BA5C /* Lint */,
+				852A98B377672F35D169D4AA /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				4E09A2845DCC354040ED8E71 /* PBXTargetDependency */,
+				D9FB760A69260BAA5DD618A9 /* PBXTargetDependency */,
 			);
 			name = Demo;
 			productName = Demo;
-			productReference = AC96F4939CA97B9ED72F17BE /* Demo.app */;
+			productReference = BBAF44EF5056FE4C19A1C005 /* Demo.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
-		A75C0FF9FEEE90909893A374 /* Project object */ = {
+		101B4AB3F10B9E0B33650F69 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0930;
 				LastUpgradeCheck = 0930;
 			};
-			buildConfigurationList = F53662C804AE9E5F1696A6FF /* Build configuration list for PBXProject "Tempura" */;
+			buildConfigurationList = F56D569E1356FC5D996DD5B8 /* Build configuration list for PBXProject "Tempura" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
 			);
-			mainGroup = 55442B1C71603DA5141094B0;
-			productRefGroup = C4B6FE672A76193A75BF55D0 /* Products */;
+			mainGroup = 5B763946694B569AB962A95A;
+			productRefGroup = A816ADC248D7D449F68C1F04 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				5736D14703646BCA3EE58B2C /* TempuraTests */,
-				0BB3B28BA7AF6FEA31555207 /* Tempura */,
-				6B4B77B288AB120BB5FB608F /* TempuraTesting */,
-				94A12E8EFBA78087651A954C /* DemoTests */,
-				B40897FF34B40A9453A704F4 /* Demo */,
+				C48B2C6F37E2641AC90FD5BB /* TempuraTests */,
+				A1389E2C90FB274567EB00F7 /* Tempura */,
+				B437ED925E4B0FBC1C6DF63B /* TempuraTesting */,
+				463B08FD56F78F2D7F0904E9 /* DemoTests */,
+				CB464AD513E869DB4BE0BB84 /* Demo */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		6CA9B47936F5513E2E867F2F /* Resources */ = {
+		20F7941CC56B714AE849116C /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5C5BD175E44EA64100FC5855 /* Media.xcassets in Resources */,
+				BFC55B9021B3EBC1BA1C8E2E /* Media.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		18F5ED8CEC8D7E175CA419E9 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-TempuraTests/Pods-TempuraTests-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/Nimble/Nimble.framework",
-				"${BUILT_PRODUCTS_DIR}/Quick/Quick.framework",
-				"${BUILT_PRODUCTS_DIR}/HydraAsync/Hydra.framework",
-				"${BUILT_PRODUCTS_DIR}/Katana/Katana.framework",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Nimble.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Quick.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Hydra.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Katana.framework",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-TempuraTests/Pods-TempuraTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		1AA4F6B7B315CF4D099DA8CA /* Lint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = Lint;
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
-			showEnvVarsInLog = 1;
-		};
-		288B8B6DF1AA9EFA1CBD6E52 /* [CP] Check Pods Manifest.lock */ = {
+		2D81A6A6600E703655BDCA9F /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -778,139 +731,14 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-TempuraTests-checkManifestLockResult.txt",
+				"$(DERIVED_FILE_DIR)/Pods-DemoTests-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		3251B7D49E0315B1514F6531 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-Tempura-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		49346C87DEFF3DF4D207C4C4 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-Tempura-Demo-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		4DBA9DFB9BE88A16CD18A67D /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-DemoTests/Pods-DemoTests-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/Nimble/Nimble.framework",
-				"${BUILT_PRODUCTS_DIR}/Quick/Quick.framework",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Nimble.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Quick.framework",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-DemoTests/Pods-DemoTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		541EFF52C25D7B36CBBE5A64 /* Lint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = Lint;
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
-			showEnvVarsInLog = 1;
-		};
-		68D3CD9B652F6A84D3785039 /* Lint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = Lint;
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
-			showEnvVarsInLog = 1;
-		};
-		860E6F711D674ECFDF08898F /* Lint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = Lint;
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
-			showEnvVarsInLog = 1;
-		};
-		986AA6BD69C29511870B0622 /* [CP] Embed Pods Frameworks */ = {
+		852A98B377672F35D169D4AA /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -938,29 +766,7 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Tempura-Demo/Pods-Tempura-Demo-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		AF01521B808FE1A25CFC1DA2 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-DemoTests-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		BD8DFC249BA8B8AC77103D31 /* Lint */ = {
+		85A81723C2FE1F5A2AAFAB60 /* Lint */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -979,7 +785,157 @@
 			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 			showEnvVarsInLog = 1;
 		};
-		DBE88299778FCB01ACDCD49D /* [CP] Check Pods Manifest.lock */ = {
+		93A8CE45B35EDACC9AEB9BF3 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Tempura-Demo-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		B4C2B9901D84F7E913D0C701 /* Lint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = Lint;
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			showEnvVarsInLog = 1;
+		};
+		B7E8C4A70B9C8DAE889BC83B /* Lint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = Lint;
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			showEnvVarsInLog = 1;
+		};
+		BF74842AFCCD239C6B97D025 /* Lint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = Lint;
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			showEnvVarsInLog = 1;
+		};
+		BFECF1A531576FC5E227BA5C /* Lint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = Lint;
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			showEnvVarsInLog = 1;
+		};
+		C58BF76DA6DA09BB3463F7B7 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${SRCROOT}/Pods/Target Support Files/Pods-DemoTests/Pods-DemoTests-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/Nimble/Nimble.framework",
+				"${BUILT_PRODUCTS_DIR}/Quick/Quick.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Nimble.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Quick.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-DemoTests/Pods-DemoTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		CBAFC27696123FC96615F475 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${SRCROOT}/Pods/Target Support Files/Pods-TempuraTests/Pods-TempuraTests-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/Nimble/Nimble.framework",
+				"${BUILT_PRODUCTS_DIR}/Quick/Quick.framework",
+				"${BUILT_PRODUCTS_DIR}/HydraAsync/Hydra.framework",
+				"${BUILT_PRODUCTS_DIR}/Katana/Katana.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Nimble.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Quick.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Hydra.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Katana.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-TempuraTests/Pods-TempuraTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		EE512BB7B33CE861B4B6BCB3 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1001,270 +957,167 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
+		F73A77013F77BF82737F6D21 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-TempuraTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		FF031E2C5E102AADE39A7FE2 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Tempura-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		6F9F7153B3A5289839C9A8A6 /* Sources */ = {
+		015C79207B40F8D2EEFBCB72 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				989E727656B535A7871D5E09 /* DemoTests.swift in Sources */,
+				1E370FD2B00374DFF537EBE4 /* DemoTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		8A574182201A3EED822FC887 /* Sources */ = {
+		01C7C9CAB4634C33B19349F5 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9DFCC81B73EFBC37624D1D02 /* UITests.swift in Sources */,
-				8B2FC280EFB4AE83905DB188 /* LocalFileURLProtocol.swift in Sources */,
-				FCDB38EA341BDA179DBC47AB /* UIView+snapshot.swift in Sources */,
-				E28B2B4AE3726FDDFC065A00 /* ViewTestCase.swift in Sources */,
-				0E778DE27B394F39E3757B5A /* ViewControllerTestCase.swift in Sources */,
+				023B2E55EA6F6515CC09CA01 /* ViewController.swift in Sources */,
+				3A953447470C5D99A21FCDDB /* View.swift in Sources */,
+				91F9C94224E0A41B70898416 /* ViewModelWithState.swift in Sources */,
+				F253D779F28B4A9A3B905CF3 /* ModellableView.swift in Sources */,
+				C0AF48F8A0304E779039A1C9 /* ViewModelWithLocalState.swift in Sources */,
+				9798EB7221816184440FB32F /* LocalState.swift in Sources */,
+				C4BE4BF296AA49B2EA1CD7B5 /* ViewModel.swift in Sources */,
+				32C3A07F35512724AF62218E /* ViewControllerModellableView.swift in Sources */,
+				CC62EE7384E4A52B69C7C078 /* ViewControllerWithLocalState.swift in Sources */,
+				07F8945CE69C6688BB72ED64 /* ViewController+Containment.swift in Sources */,
+				FE9490F117ECFA1719696264 /* UINavigationController+Completion.swift in Sources */,
+				8EBEDA303350F64E9A9C2C38 /* NavigationActions.swift in Sources */,
+				4341E878EE83314B6A801717 /* NavigationUtilities.swift in Sources */,
+				1163C5E52A677CB22E5CD9A0 /* Routable.swift in Sources */,
+				E2D53B45A5CDFAA6856CCBD2 /* RootInstaller.swift in Sources */,
+				674514354BCD474FB056CD0F /* NavigationDSL.swift in Sources */,
+				9C7F4113B320E72C925BED61 /* NavigationProvider.swift in Sources */,
+				2536845090987BAFE69E3CCB /* Navigator.swift in Sources */,
+				7B8D1B373BECFB4DF432719F /* MainThread.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		939F74F151489A95AA924EB9 /* Sources */ = {
+		6E5F054AAB054A4D8DD8F99D /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3559EB204BCE49BADAAF335D /* ListViewController.swift in Sources */,
-				99969FB0412492F5077B102B /* ListView.swift in Sources */,
-				7CD20FD1667FDB8EE0017DE7 /* ArchiveFlowLayout.swift in Sources */,
-				13CAE0C88EB5254F94A21463 /* TodoCell.swift in Sources */,
-				E13A0C90D4640E18FF0880E2 /* TodoFlowLayout.swift in Sources */,
-				F8F822E4B098F13F2DB5A578 /* ChildViewController.swift in Sources */,
-				3E627D12CEC07D27406B001E /* TextView.swift in Sources */,
-				09CB0E2CE34D361C4BDBE1C4 /* AddItemView.swift in Sources */,
-				993ACA741AB63E778227FF39 /* AddItemViewController.swift in Sources */,
-				4BB37619133E8729BC2C041B /* AppNavigation.swift in Sources */,
-				5ABC048564C5B122B6D09185 /* DependenciesContainer.swift in Sources */,
-				6B9E8EA42A3D832F45DC547E /* AppState.swift in Sources */,
-				4B502C344826317DA9E27131 /* Models.swift in Sources */,
-				C30B936D219CF71BA14045C8 /* UIControl+TargetActionable.swift in Sources */,
-				6BBD0B7EB76AC938AB15361B /* String+Random.swift in Sources */,
-				475ECDA278A66D5BF495AA2C /* Source.swift in Sources */,
-				C2F4EFFABFB80443DA05A435 /* CollectionView.swift in Sources */,
-				76F03EDAC31AFCD914F76DC4 /* DataSource.swift in Sources */,
-				9A3A51A45ABD9CE89AAAD6C6 /* ConfigurableCell.swift in Sources */,
-				F14E2316F3F3926EA364BF07 /* CGRect+Utils.swift in Sources */,
-				9D52A3A6FF1574FA2D621CD8 /* UIView+Blink.swift in Sources */,
-				158697D77424E08A69FE8E3B /* String+Height.swift in Sources */,
-				F81A83A0017193192CC27BF7 /* ItemActions.swift in Sources */,
-				4C46CB4B012429DF7A383272 /* AppDelegate.swift in Sources */,
+				8C5F207EF9411D751B819A41 /* ListViewController.swift in Sources */,
+				1E21668168EDE22906AE27F3 /* ListView.swift in Sources */,
+				D2DE2B562687B35C904C0028 /* ArchiveFlowLayout.swift in Sources */,
+				FB3EDB89F6BC0CA2B4287944 /* TodoCell.swift in Sources */,
+				611893E6A50CE035458C1195 /* TodoFlowLayout.swift in Sources */,
+				14274D8328FE809BBA2B57AB /* ChildViewController.swift in Sources */,
+				6A93E67F344699072FC1AE55 /* TextView.swift in Sources */,
+				37580751D4678B066DB74198 /* AddItemView.swift in Sources */,
+				3D7350791FDE088C51F51EDE /* AddItemViewController.swift in Sources */,
+				E85812746E8F505ACF6E0A79 /* AppNavigation.swift in Sources */,
+				3486EFF679DC63B0EB845AC2 /* DependenciesContainer.swift in Sources */,
+				E1A7747F0F7EA42D16E5FE4B /* AppState.swift in Sources */,
+				F30A835FE4E0691E789AC66C /* Models.swift in Sources */,
+				24EC50B5A1C823CC9FA9B434 /* UIControl+TargetActionable.swift in Sources */,
+				3D756AAB4D795A62E5E9F5C8 /* String+Random.swift in Sources */,
+				54C5CF2D9601D836BE70F179 /* Source.swift in Sources */,
+				1CD83C17A5732AD886C73736 /* CollectionView.swift in Sources */,
+				3EEDFD19910FDA5D7DCED462 /* DataSource.swift in Sources */,
+				942FDEF9F962A28778AA8537 /* ConfigurableCell.swift in Sources */,
+				C3B38CB3CECD8E4AA896D66D /* CGRect+Utils.swift in Sources */,
+				920B75CE180884361EFDF2D2 /* UIView+Blink.swift in Sources */,
+				0A97DB1E29A6E85F5374431B /* String+Height.swift in Sources */,
+				58A6370A15C64FE1066CFF58 /* ItemActions.swift in Sources */,
+				72B721F2777B1888E4A0C3C2 /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		A7E54BF057BD82107244AF7C /* Sources */ = {
+		B495761916DA4A81B728CD58 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				999234490DC4E673A7C70DBE /* ViewController.swift in Sources */,
-				E6314C48918F9F9733FB5053 /* View.swift in Sources */,
-				CE92FDE1576ADE01EEC6EB52 /* ViewModelWithState.swift in Sources */,
-				C3CDFE70200644F3CF7DB1B8 /* ModellableView.swift in Sources */,
-				99C36F19AAB7E54421A8763B /* ViewModelWithLocalState.swift in Sources */,
-				25D9DF6EE8708EF67CCAF182 /* LocalState.swift in Sources */,
-				FE70E34725740D9E51229D2E /* ViewModel.swift in Sources */,
-				85558A12B9416CD5D78156C5 /* ViewControllerModellableView.swift in Sources */,
-				680BCF772690C6137804B025 /* ViewControllerWithLocalState.swift in Sources */,
-				502C84C9B3DBA6D29A6FDCA6 /* ViewController+Containment.swift in Sources */,
-				D2210FAE5324220A47E087D2 /* UINavigationController+Completion.swift in Sources */,
-				F5E29E23E087AC4FE3ADDC62 /* NavigationActions.swift in Sources */,
-				322C48A936CD4FDC8D21FEAC /* NavigationUtilities.swift in Sources */,
-				35A83C0BB92E608F0B4BD174 /* Routable.swift in Sources */,
-				CECD601EB2F0393A0FDF136C /* RootInstaller.swift in Sources */,
-				249A651327AACCC8BAAF7AD0 /* NavigationDSL.swift in Sources */,
-				24C7830B83527540086D7463 /* NavigationProvider.swift in Sources */,
-				BB44B0EC81A1E5D513946DE8 /* Navigator.swift in Sources */,
-				F04DA01F951CE83C732B3FA9 /* MainThread.swift in Sources */,
+				7E56F8F16969F420D787F5EF /* ViewControllerSpec.swift in Sources */,
+				9F9467DC10A1BAFA49E1BAF7 /* ViewControllerWithLocalStateSpec.swift in Sources */,
+				FBC676737718804E7F8580BD /* ViewControlerContainmentSpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		B095848C621FB72FE5C6D319 /* Sources */ = {
+		D82D49D39A8D730457CC9584 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D9F516B5314B0214EFC05B23 /* ViewControllerSpec.swift in Sources */,
-				0767353C79D7B582D3C24434 /* ViewControllerWithLocalStateSpec.swift in Sources */,
-				3D721DA4FF25018C0BFBD3BF /* ViewControlerContainmentSpec.swift in Sources */,
+				EA7CDA869947054BC9341697 /* UITests.swift in Sources */,
+				F38B0513BF60D65E976FFE1C /* LocalFileURLProtocol.swift in Sources */,
+				1852F2EA800B4FD27CCE41F7 /* UIView+snapshot.swift in Sources */,
+				BA084013FEEE77DF808AE57B /* ViewTestCase.swift in Sources */,
+				FF7CA16B97C2BECE5ECB6506 /* ViewControllerTestCase.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		4E09A2845DCC354040ED8E71 /* PBXTargetDependency */ = {
+		D9FB760A69260BAA5DD618A9 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = Tempura;
-			target = 0BB3B28BA7AF6FEA31555207 /* Tempura */;
-			targetProxy = 42F44F9E1FA3CF92F01447F3 /* PBXContainerItemProxy */;
+			target = A1389E2C90FB274567EB00F7 /* Tempura */;
+			targetProxy = ED8AD01F9BFCAFA7002460A2 /* PBXContainerItemProxy */;
 		};
-		AB99E69902469ED6BC89CA1F /* PBXTargetDependency */ = {
+		E54FD27DE6C478213BC5EBEE /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = Demo;
-			target = B40897FF34B40A9453A704F4 /* Demo */;
-			targetProxy = E909C03848D0B2F86C44B249 /* PBXContainerItemProxy */;
+			target = CB464AD513E869DB4BE0BB84 /* Demo */;
+			targetProxy = C92FC67FD9AEF081F464FF4A /* PBXContainerItemProxy */;
 		};
-		E920D0835C736C8F8BFBA55A /* PBXTargetDependency */ = {
+		F1436317566FD62CE02091AF /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = Tempura;
-			target = 0BB3B28BA7AF6FEA31555207 /* Tempura */;
-			targetProxy = 3CD6039341409C7CDE0388D2 /* PBXContainerItemProxy */;
+			target = A1389E2C90FB274567EB00F7 /* Tempura */;
+			targetProxy = 8E27D9B525DC526CB4E7A278 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		1557E0E731F7B5DF4C2814E8 /* Release */ = {
+		13415D7D29FA249960F8D513 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 9227BEDCE271A1F7321C284B /* Pods-TempuraTesting.release.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				INFOPLIST_FILE = Tempura/SupportingFiles/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_NAME = TempuraTesting;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_OPTIMIZATION_LEVEL = "-O";
-				SWIFT_VERSION = 4.2;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		16B7705AA773818CC6B85397 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_ANALYZER_NONNULL = YES;
-				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_ENABLE_OBJC_WEAK = YES;
-				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_COMMA = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INFINITE_RECURSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-				CLANG_WARN_STRICT_PROTOTYPES = YES;
-				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				ENABLE_NS_ASSERTIONS = NO;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu11;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				MTL_FAST_MATH = YES;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-			};
-			name = Release;
-		};
-		2198A1C9E6A03546557ABCA8 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6DA6940A28CA669448815865 /* Pods-TempuraTests.debug.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				INFOPLIST_FILE = TempuraTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				SDKROOT = iphoneos;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
-			};
-			name = Debug;
-		};
-		36CAC2A9F1C83D85F73E29C2 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 3EFDDD90C3FA3CCD520AFBC0 /* Pods-DemoTests.release.xcconfig */;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				INFOPLIST_FILE = DemoTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				SDKROOT = iphoneos;
-				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_OPTIMIZATION_LEVEL = "-O";
-				SWIFT_VERSION = 4.2;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Demo.app/Demo";
-				VALIDATE_PRODUCT = YES;
-			};
-			name = Release;
-		};
-		3F9BA74C1555F7312E094275 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0C17ADD6BE8EC9F20CD38063 /* Pods-TempuraTests.release.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				INFOPLIST_FILE = TempuraTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				SDKROOT = iphoneos;
-				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_OPTIMIZATION_LEVEL = "-O";
-				SWIFT_VERSION = 4.2;
-				VALIDATE_PRODUCT = YES;
-			};
-			name = Release;
-		};
-		58D69BDD9F14B58365C15956 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = AAA0176238B5AE3D13232386 /* Pods-DemoTests.debug.xcconfig */;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				INFOPLIST_FILE = DemoTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				SDKROOT = iphoneos;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Demo.app/Demo";
-			};
-			name = Debug;
-		};
-		59F8D24538EB6398D788D57D /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = F82EB8257C9C2A596D0FB19E /* Pods-TempuraTesting.debug.xcconfig */;
+			baseConfigurationReference = 394C8A329E3FAA10F9F84289 /* Pods-TempuraTesting.debug.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				CURRENT_PROJECT_VERSION = 1;
@@ -1292,7 +1145,7 @@
 			};
 			name = Debug;
 		};
-		5E8FD99E858A8C8AD629B2BE /* Debug */ = {
+		13831FFEF3207A5F819D79C7 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -1349,9 +1202,9 @@
 			};
 			name = Debug;
 		};
-		6AF048D240120E59592B05AD /* Debug */ = {
+		27629DF3A21207440B69A56D /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = E17A5C015B2119C6FCA17010 /* Pods-Tempura.debug.xcconfig */;
+			baseConfigurationReference = 5110CAB236448B4251605A4B /* Pods-Tempura.debug.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				CURRENT_PROJECT_VERSION = 1;
@@ -1379,9 +1232,94 @@
 			};
 			name = Debug;
 		};
-		A7002759E9B8EEF69D20FBEC /* Debug */ = {
+		2E7CEE8AAC3767F94D6610A3 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = AF2D3A78299905F0BE23C86A /* Pods-Tempura-Demo.debug.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+		347E2C90FCE8B4A1DBFC627C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 16C40E6D80AA7E566F489B8F /* Pods-DemoTests.debug.xcconfig */;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				INFOPLIST_FILE = DemoTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.2;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Demo.app/Demo";
+			};
+			name = Debug;
+		};
+		8E0C41833FD8E9BFC771A5FD /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 983B8A3CFB70568DA097AEF2 /* Pods-DemoTests.release.xcconfig */;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				INFOPLIST_FILE = DemoTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 4.2;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Demo.app/Demo";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		A80C2D3414466298511B81FD /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 75BE789CC542C89BCA59BC4E /* Pods-Tempura-Demo.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -1398,9 +1336,9 @@
 			};
 			name = Debug;
 		};
-		D2E0B61635E91EB0A801678A /* Release */ = {
+		B34AB5EA57D5B8B4FC1F8DB1 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7603DC076EB3DA6CA2580F72 /* Pods-Tempura-Demo.release.xcconfig */;
+			baseConfigurationReference = 7C7DC56CCC5BE14482AEE335 /* Pods-Tempura-Demo.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -1418,9 +1356,40 @@
 			};
 			name = Release;
 		};
-		F61C6E40A598620183B93248 /* Release */ = {
+		D09006EF1BB1D9BF8EC1CFE8 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = AE1DAFC1C3E18EBCF6C6D33E /* Pods-Tempura.release.xcconfig */;
+			baseConfigurationReference = C31978FB6F338CDAB9A0D41D /* Pods-TempuraTesting.release.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				INFOPLIST_FILE = Tempura/SupportingFiles/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = TempuraTesting;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 4.2;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		D2A22D25A08063389B700985 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 02648BE03503594F16E1BACF /* Pods-Tempura.release.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				CURRENT_PROJECT_VERSION = 1;
@@ -1448,65 +1417,96 @@
 				VERSION_INFO_PREFIX = "";
 			};
 			name = Release;
+		};
+		E4F8E8EC30A8942D4763459F /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 6CF97798DD5CC9299245340B /* Pods-TempuraTests.release.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				INFOPLIST_FILE = TempuraTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 4.2;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		EEBC193EFBA934979560F0DA /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 189627DB71A20362FA1BF928 /* Pods-TempuraTests.debug.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				INFOPLIST_FILE = TempuraTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.2;
+			};
+			name = Debug;
 		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		3468A8E5D8C569DDB5FC51A6 /* Build configuration list for PBXNativeTarget "TempuraTests" */ = {
+		636E5367004736B36D6066E4 /* Build configuration list for PBXNativeTarget "Tempura" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				2198A1C9E6A03546557ABCA8 /* Debug */,
-				3F9BA74C1555F7312E094275 /* Release */,
+				27629DF3A21207440B69A56D /* Debug */,
+				D2A22D25A08063389B700985 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		683D8930F105AFFD4A370C14 /* Build configuration list for PBXNativeTarget "TempuraTesting" */ = {
+		68475462C31C9266B3CE2128 /* Build configuration list for PBXNativeTarget "DemoTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				59F8D24538EB6398D788D57D /* Debug */,
-				1557E0E731F7B5DF4C2814E8 /* Release */,
+				347E2C90FCE8B4A1DBFC627C /* Debug */,
+				8E0C41833FD8E9BFC771A5FD /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		C314B63FAD28A3CCF5D166C0 /* Build configuration list for PBXNativeTarget "Demo" */ = {
+		CE865A114656481F78AA7A53 /* Build configuration list for PBXNativeTarget "Demo" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				A7002759E9B8EEF69D20FBEC /* Debug */,
-				D2E0B61635E91EB0A801678A /* Release */,
+				A80C2D3414466298511B81FD /* Debug */,
+				B34AB5EA57D5B8B4FC1F8DB1 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		CE0E8790398EDBBE82599B53 /* Build configuration list for PBXNativeTarget "Tempura" */ = {
+		D10317CDE194193B53048089 /* Build configuration list for PBXNativeTarget "TempuraTesting" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				6AF048D240120E59592B05AD /* Debug */,
-				F61C6E40A598620183B93248 /* Release */,
+				13415D7D29FA249960F8D513 /* Debug */,
+				D09006EF1BB1D9BF8EC1CFE8 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		E4CD0F9FFEA41BAC718CCDA6 /* Build configuration list for PBXNativeTarget "DemoTests" */ = {
+		ECB39273DF7F033DE9E4BF50 /* Build configuration list for PBXNativeTarget "TempuraTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				58D69BDD9F14B58365C15956 /* Debug */,
-				36CAC2A9F1C83D85F73E29C2 /* Release */,
+				EEBC193EFBA934979560F0DA /* Debug */,
+				E4F8E8EC30A8942D4763459F /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		F53662C804AE9E5F1696A6FF /* Build configuration list for PBXProject "Tempura" */ = {
+		F56D569E1356FC5D996DD5B8 /* Build configuration list for PBXProject "Tempura" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				5E8FD99E858A8C8AD629B2BE /* Debug */,
-				16B7705AA773818CC6B85397 /* Release */,
+				13831FFEF3207A5F819D79C7 /* Debug */,
+				2E7CEE8AAC3767F94D6610A3 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};
-	rootObject = A75C0FF9FEEE90909893A374 /* Project object */;
+	rootObject = 101B4AB3F10B9E0B33650F69 /* Project object */;
 }

--- a/Tempura.xcodeproj/xcshareddata/xcschemes/Demo.xcscheme
+++ b/Tempura.xcodeproj/xcshareddata/xcschemes/Demo.xcscheme
@@ -14,7 +14,7 @@
             buildForArchiving = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "B40897FF34B40A9453A704F4"
+               BlueprintIdentifier = "CB464AD513E869DB4BE0BB84"
                BlueprintName = "Demo"
                ReferencedContainer = "container:Tempura.xcodeproj"
                BuildableName = "Demo.app">
@@ -28,7 +28,7 @@
             buildForArchiving = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "94A12E8EFBA78087651A954C"
+               BlueprintIdentifier = "463B08FD56F78F2D7F0904E9"
                BlueprintName = "DemoTests"
                ReferencedContainer = "container:Tempura.xcodeproj"
                BuildableName = "DemoTests.xctest">
@@ -48,7 +48,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "94A12E8EFBA78087651A954C"
+               BlueprintIdentifier = "463B08FD56F78F2D7F0904E9"
                BlueprintName = "DemoTests"
                ReferencedContainer = "container:Tempura.xcodeproj"
                BuildableName = "DemoTests.xctest">
@@ -72,7 +72,7 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "B40897FF34B40A9453A704F4"
+            BlueprintIdentifier = "CB464AD513E869DB4BE0BB84"
             BlueprintName = "Demo"
             ReferencedContainer = "container:Tempura.xcodeproj"
             BuildableName = "Demo.app">
@@ -88,7 +88,7 @@
       <BuildableProductRunnable>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "B40897FF34B40A9453A704F4"
+            BlueprintIdentifier = "CB464AD513E869DB4BE0BB84"
             BlueprintName = "Demo"
             ReferencedContainer = "container:Tempura.xcodeproj"
             BuildableName = "Demo.app">

--- a/Tempura.xcodeproj/xcshareddata/xcschemes/Tempura.xcscheme
+++ b/Tempura.xcodeproj/xcshareddata/xcschemes/Tempura.xcscheme
@@ -7,76 +7,56 @@
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry
+            buildForAnalyzing = "YES"
             buildForTesting = "NO"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "NO"
-            buildForAnalyzing = "YES">
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "0BB3B28BA7AF6FEA31555207"
-               BuildableName = "Tempura.framework"
+               BlueprintIdentifier = "A1389E2C90FB274567EB00F7"
                BlueprintName = "Tempura"
-               ReferencedContainer = "container:Tempura.xcodeproj">
+               ReferencedContainer = "container:Tempura.xcodeproj"
+               BuildableName = "Tempura.framework">
             </BuildableReference>
          </BuildActionEntry>
          <BuildActionEntry
+            buildForAnalyzing = "YES"
             buildForTesting = "YES"
             buildForRunning = "NO"
             buildForProfiling = "NO"
-            buildForArchiving = "NO"
-            buildForAnalyzing = "YES">
+            buildForArchiving = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "5736D14703646BCA3EE58B2C"
-               BuildableName = "TempuraTests.xctest"
+               BlueprintIdentifier = "C48B2C6F37E2641AC90FD5BB"
                BlueprintName = "TempuraTests"
-               ReferencedContainer = "container:Tempura.xcodeproj">
+               ReferencedContainer = "container:Tempura.xcodeproj"
+               BuildableName = "TempuraTests.xctest">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <AdditionalOptions>
+      </AdditionalOptions>
       <Testables>
          <TestableReference
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "5736D14703646BCA3EE58B2C"
-               BuildableName = "TempuraTests.xctest"
+               BlueprintIdentifier = "C48B2C6F37E2641AC90FD5BB"
                BlueprintName = "TempuraTests"
-               ReferencedContainer = "container:Tempura.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "94A12E8EFBA78087651A954C"
-               BuildableName = "DemoTests.xctest"
-               BlueprintName = "DemoTests"
-               ReferencedContainer = "container:Tempura.xcodeproj">
+               ReferencedContainer = "container:Tempura.xcodeproj"
+               BuildableName = "TempuraTests.xctest">
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "0BB3B28BA7AF6FEA31555207"
-            BuildableName = "Tempura.framework"
-            BlueprintName = "Tempura"
-            ReferencedContainer = "container:Tempura.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
@@ -84,34 +64,34 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      buildConfiguration = "Debug"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "0BB3B28BA7AF6FEA31555207"
-            BuildableName = "Tempura.framework"
-            BlueprintName = "Tempura"
-            ReferencedContainer = "container:Tempura.xcodeproj">
-         </BuildableReference>
-      </BuildableProductRunnable>
       <AdditionalOptions>
       </AdditionalOptions>
-   </LaunchAction>
-   <ProfileAction
-      buildConfiguration = "Debug"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      savedToolIdentifier = ""
-      useCustomWorkingDirectory = "NO"
-      debugDocumentVersioning = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "0BB3B28BA7AF6FEA31555207"
-            BuildableName = "Tempura.framework"
+            BlueprintIdentifier = "A1389E2C90FB274567EB00F7"
             BlueprintName = "Tempura"
-            ReferencedContainer = "container:Tempura.xcodeproj">
+            ReferencedContainer = "container:Tempura.xcodeproj"
+            BuildableName = "Tempura.framework">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES"
+      buildConfiguration = "Debug"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <BuildableProductRunnable>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A1389E2C90FB274567EB00F7"
+            BlueprintName = "Tempura"
+            ReferencedContainer = "container:Tempura.xcodeproj"
+            BuildableName = "Tempura.framework">
          </BuildableReference>
       </BuildableProductRunnable>
    </ProfileAction>

--- a/Tempura.xcodeproj/xcshareddata/xcschemes/TempuraTesting.xcscheme
+++ b/Tempura.xcodeproj/xcshareddata/xcschemes/TempuraTesting.xcscheme
@@ -14,7 +14,7 @@
             buildForArchiving = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "6B4B77B288AB120BB5FB608F"
+               BlueprintIdentifier = "B437ED925E4B0FBC1C6DF63B"
                BlueprintName = "TempuraTesting"
                ReferencedContainer = "container:Tempura.xcodeproj"
                BuildableName = "TempuraTesting.framework">
@@ -46,7 +46,7 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "6B4B77B288AB120BB5FB608F"
+            BlueprintIdentifier = "B437ED925E4B0FBC1C6DF63B"
             BlueprintName = "TempuraTesting"
             ReferencedContainer = "container:Tempura.xcodeproj"
             BuildableName = "TempuraTesting.framework">
@@ -62,7 +62,7 @@
       <BuildableProductRunnable>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "6B4B77B288AB120BB5FB608F"
+            BlueprintIdentifier = "B437ED925E4B0FBC1C6DF63B"
             BlueprintName = "TempuraTesting"
             ReferencedContainer = "container:Tempura.xcodeproj"
             BuildableName = "TempuraTesting.framework">

--- a/Tempura/UITests/UITests.swift
+++ b/Tempura/UITests/UITests.swift
@@ -296,8 +296,8 @@ public enum UITests {
   private static func saveImage(_ image: UIImage, description: String) {
     guard var dirPath = Bundle.main.infoDictionary?["UI_TEST_DIR"] as? String else { fatalError("UI_TEST_DIR not defined in your info.plist") }
     
-    if let languageCode = Locale.current.languageCode {
-      dirPath = dirPath.appending("/\(languageCode)/")
+    if let collatorIdentifier = Locale.current.collatorIdentifier {
+      dirPath = dirPath.appending("/\(collatorIdentifier)/")
     }
     let screenSize = UIScreen.main.bounds.size
     let screenSizeDescription: String = "\(min(screenSize.width, screenSize.height))x\(max(screenSize.width, screenSize.height))"


### PR DESCRIPTION
**Why**
The ui tests are broken when using languages with multiple variants, like zh-Hans (chinese simplified) and zh-Hant (chinese traditional).
The old implementation used the `languageCode` and for both those languages it was `zh` so the screenshots generated by the second language end up overriding the ones generated by the first one.
By using the `collatorIdentifier`, instead, the two are kept separated.

The `collatorIdentifier` works as the `languageCode` for all the languages without multiple variants. So, for example, for the `en-US` locale both the `languageCode` and the `collatorIdentifier` return `en`.

**Changes**
No public API has been changed.

**Tasks**
* [x] Add relevant tests, if needed
* [x] Add documentation, if needed
* [x] Update README, if needed
* [x] Ensure that the demo project works properly