### PR TITLE
[Fix] Fixed unresolving promise if calling `hide` on a view that is not in the `currentRoutables`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## master
+* Fixed unresolving promise if calling `hide` on a view that is not in the `currentRoutables`
+
 ## 4.0.0
 * Add support for Swift 5.0
 * Remove `init()` requirement for `LocalState` protocol

--- a/Tempura/Navigation/Navigator.swift
+++ b/Tempura/Navigation/Navigator.swift
@@ -262,6 +262,7 @@ public class Navigator {
       let oldRoute = oldRoutables.map { $0.routeIdentifier }
       
       guard let start = oldRoute.indices.reversed().first(where: { oldRoute[$0] == elementToHide }) else {
+        resolve(())
         return
       }
       


### PR DESCRIPTION
In the past, we decided we wanted to support transparently hiding a view that is not being shown. However, the promise inside `hide` does not resolve if that is the case, leaving anyone awaiting for it stuck forever.