### PR TITLE
[Fix] Scrollable View UITest filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## master
+* Fixed broken UITest filename for a scrollable content's snapshot
+
 ## 4.0.1
 * Fixed unresolving promise if calling `hide` on a view that is not in the `currentRoutables`
 * `ViewControllerWithLocalState.init(store:connected:)` is now private

--- a/Tempura/UITests/ViewTestCase.swift
+++ b/Tempura/UITests/ViewTestCase.swift
@@ -100,7 +100,7 @@ public extension ViewTestCase where Self: XCTestCase {
                             isViewReadyClosure: isViewReadyClosure) {
                               // ScrollViews snapshot
                               self.scrollViewsToTest(in: vcs.contained.view as! V, identifier: identifier).forEach { entry in
-                                UITests.snapshotScrollableContent(entry.value, description: "\(identifier)_\(entry.key)")
+                                UITests.snapshotScrollableContent(entry.value, description: "\(identifier)_scrollable_content \(screenSizeDescription)")
                               }
                               expectation.fulfill()
       }


### PR DESCRIPTION
This fixes a broken UITest filename for the scrollable content snapshot.