### PR TITLE
[Feature] Make closure in installRoot escaping

### DIFF
--- a/Tempura/Navigation/RootInstaller.swift
+++ b/Tempura/Navigation/RootInstaller.swift
@@ -52,5 +52,5 @@ public protocol RootInstaller {
   ///      }
   /// ```
   @discardableResult
-  func installRoot(identifier: RouteElementIdentifier, context: Any?, completion: Navigator.Completion) -> Bool
+  func installRoot(identifier: RouteElementIdentifier, context: Any?, completion: @escaping Navigator.Completion) -> Bool
 }


### PR DESCRIPTION
**Why**
To make sure we can pass it to external functions rather than restricting us to use it only inside the `instalRoot(identifier:context:completion:)` function body.

**Changes**
No major changes, just added the `@escaping` keyword before the closure type.

**Tasks**
* [ ] Add relevant tests, if needed
* [ ] Add documentation, if needed
* [ ] Update README, if needed
* [x] Ensure that the demo project works properly