### PR TITLE
Update Modal Navigation to support iOS 13

### DIFF
--- a/Tempura/Navigation/NavigationUtilities.swift
+++ b/Tempura/Navigation/NavigationUtilities.swift
@@ -22,6 +22,10 @@ public extension UIViewController {
       vc.recursivePresent(viewController, animated: animated, completion: completion)
     } else {
       viewController.toBeDismissed = false
+      #warning("This is a temporary fix in order to keep the behaviour of the apps as is in iOS 13 before opting for a more stable solution.")
+      if #available(iOS 13, *) {
+        viewController.modalPresentationStyle = .fullScreen
+      } 
       self.present(viewController, animated: animated, completion: completion)
     }
     


### PR DESCRIPTION

This temporary fix ensures that all apps released are identical on all iOS before implementing a more robust solution that supports new designs and different desired behaviors.

This is especially critical when paywalls are presented modally and therefore can be dismissed with a simple swipe.

**Why**
With iOS 13 releasing, and new changes being introduced, a `non-backward compatible` change is the default behavior of modal screens, better explained here: https://medium.com/@hacknicity/view-controller-presentation-changes-in-ios-13-ac8c901ebc4e

**Changes**
Added `viewController.modalPresentationStyle = .fullScreen` to `recursivePresent` responsible for modal presentation.

**Tasks**
* [ ] Add relevant tests, if needed
* [x] Add documentation, if needed
* [x] Update README, if needed
* [ ] Ensure that the demo project works properly