### PR TITLE
[Fix] Remove custom edges behavior from HookableViewController

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -6,7 +6,7 @@ PODS:
   - Nimble (7.3.4)
   - PinLayout (1.7.4)
   - Quick (1.3.0)
-  - Tempura (4.1.0):
+  - Tempura (4.1.2):
     - Katana (< 4, >= 3.0)
 
 DEPENDENCIES:
@@ -19,7 +19,7 @@ DEPENDENCIES:
   - Tempura (from `.`)
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  https://github.com/CocoaPods/Specs.git:
     - DeepDiff
     - HydraAsync
     - Katana
@@ -38,8 +38,8 @@ SPEC CHECKSUMS:
   Nimble: 051e3d8912d40138fa5591c78594f95fb172af37
   PinLayout: 7903960df1061eeebd393690286df73e002d9b20
   Quick: 03278013f71aa05fe9ecabc94fbcc6835f1ee76f
-  Tempura: c6ffab3c20257f5812c59c38ecad19ab57f60e0a
+  Tempura: eb5426b9ae795fd2c83f6c5809dba824959a30eb
 
 PODFILE CHECKSUM: 38702d0c43f34b8b0ef75f4af24856ae2bace63d
 
-COCOAPODS: 1.6.1
+COCOAPODS: 1.8.4

--- a/Tempura/UITests/UITests.swift
+++ b/Tempura/UITests/UITests.swift
@@ -164,9 +164,6 @@ public enum UITests {
     override func viewDidLoad() {
       super.viewDidLoad()
       
-      self.automaticallyAdjustsScrollViewInsets = false
-      self.edgesForExtendedLayout = []
-      
       if let hook = self.hooks?[.viewDidLoad] {
         hook(self.rootView)
       }


### PR DESCRIPTION
**Why**
This PR removes the following instructions:
`self.automaticallyAdjustsScrollViewInsets = false`
`self.edgesForExtendedLayout = []`

from inside the UITestCase implementation, that modified the insets of scrollViews to avoid them being drawn under navigation bars or tab bars. This is not always the desired behaviour of a view, so its UITests would create a wrong screenshot with respect to the real behaviour. If this behaviour is desired for a particular `ViewTestCase`, the same code can be added through the `.viewDidLoad` hook.

**Changes**
No API change, just removed the mentioned lines from the internal implementation of `HookableViewController`.