### PR TITLE
[Feat] Add mock Safe Area Insets to UITests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.3.0
+* Add support for rendering Safe Area Insets in UITests
+
 ## 4.2.0
 * Add transition method to the Containment API
 

--- a/Tempura/UITests/UITests.swift
+++ b/Tempura/UITests/UITests.swift
@@ -258,11 +258,11 @@ public enum UITests {
     self.saveImage(image, description: description)
   }
   
-  static func asyncSnapshot(view: UIView, viewToWaitFor: UIView? = nil, description: String, isViewReadyClosure: @escaping (UIView) -> Bool, completionClosure: @escaping () -> Void) {
+  static func asyncSnapshot(view: UIView, viewToWaitFor: UIView? = nil, description: String, isViewReadyClosure: @escaping (UIView) -> Bool, shouldRenderSafeArea: Bool, completionClosure: @escaping () -> Void) {
     let frame = UIScreen.main.bounds
     view.frame = frame
     
-    view.snapshotAsync(viewToWaitFor: viewToWaitFor, isViewReadyClosure: isViewReadyClosure) { snapshot in
+    view.snapshotAsync(viewToWaitFor: viewToWaitFor, isViewReadyClosure: isViewReadyClosure, shouldRenderSafeArea: shouldRenderSafeArea) { snapshot in
       defer {
         completionClosure()
       }

--- a/Tempura/UITests/ViewControllerTestCase.swift
+++ b/Tempura/UITests/ViewControllerTestCase.swift
@@ -99,7 +99,8 @@ public extension ViewControllerTestCase where Self: XCTestCase {
       UITests.asyncSnapshot(view: vcs.container.view,
                             viewToWaitFor: (vcs.contained as! UIViewController).view,
                             description: description,
-                            isViewReadyClosure: isViewReadyClosure) {
+                            isViewReadyClosure: isViewReadyClosure,
+                            shouldRenderSafeArea: context.renderSafeArea) {
                               expectation.fulfill()
       }
       
@@ -145,15 +146,20 @@ extension UITests {
     
     /// the orientation of the view
     public var orientation: UIDeviceOrientation
+
+    /// whether black dimmed rectangles should be rendered showing the safe area insets
+    public var renderSafeArea: Bool
     
     public init(container: Container = .none,
                 hooks: [UITests.Hook: UITests.HookClosure<VC.V>] = [:],
                 screenSize: CGSize = UIScreen.main.bounds.size,
-                orientation: UIDeviceOrientation = .portrait) {
+                orientation: UIDeviceOrientation = .portrait,
+                renderSafeArea: Bool = false) {
       self.container = container
       self.hooks = hooks
       self.screenSize = screenSize
       self.orientation = orientation
+      self.renderSafeArea = renderSafeArea
     }
   }
 }

--- a/Tempura/UITests/ViewTestCase.swift
+++ b/Tempura/UITests/ViewTestCase.swift
@@ -97,7 +97,8 @@ public extension ViewTestCase where Self: XCTestCase {
       UITests.asyncSnapshot(view: vcs.container.view,
                             viewToWaitFor: vcs.contained.view,
                             description: description,
-                            isViewReadyClosure: isViewReadyClosure) {
+                            isViewReadyClosure: isViewReadyClosure,
+                            shouldRenderSafeArea: context.renderSafeArea) {
                               // ScrollViews snapshot
                               self.scrollViewsToTest(in: vcs.contained.view as! V, identifier: identifier).forEach { entry in
                                 UITests.snapshotScrollableContent(entry.value, description: "\(identifier)_scrollable_content \(screenSizeDescription)")
@@ -150,15 +151,20 @@ extension UITests {
     
     /// the orientation of the view
     public var orientation: UIDeviceOrientation
+
+    /// whether black dimmed rectangles should be rendered showing the safe area insets
+    public var renderSafeArea: Bool
     
     public init(container: Container = .none,
                 hooks: [UITests.Hook: UITests.HookClosure<V>] = [:],
                 screenSize: CGSize = UIScreen.main.bounds.size,
-                orientation: UIDeviceOrientation = .portrait) {
+                orientation: UIDeviceOrientation = .portrait,
+                renderSafeArea: Bool = false) {
       self.container = container
       self.hooks = hooks
       self.screenSize = screenSize
       self.orientation = orientation
+      self.renderSafeArea = renderSafeArea
     }
   }
 }


### PR DESCRIPTION
**Why**
This PR adds the support to show the Safe Area insets in UITests.

**Changes**
New property `renderSafeArea` in Context (both for Views and ViewControllers)

**Tasks**
* [x] Add relevant tests, if needed
* [x] Add documentation, if needed
* [x] Update README, if needed
* [x] Ensure that the demo project works properly