### PR TITLE
Review view controller builder

### DIFF
--- a/Tempura/UITests/UITests.swift
+++ b/Tempura/UITests/UITests.swift
@@ -32,13 +32,13 @@ public enum UITests {
   
   
   public struct VCScreenSnapshot<VC: UIViewController, V: UIView> {
-    let vc: () -> VC
+    let vc: (String) -> VC
     let container: Container
     let testCases: [String]
     let hooks: [Hook: HookViewClosure<V>]
     let size: CGSize
     
-    init(vc: @autoclosure @escaping () -> VC, container: Container, testCases: [String], hooks: [Hook: HookViewClosure<V>], size: CGSize) {
+    init(vc: @escaping (String) -> VC, container: Container, testCases: [String], hooks: [Hook: HookViewClosure<V>], size: CGSize) {
       self.vc = vc
       self.container = container
       self.testCases = testCases
@@ -48,7 +48,7 @@ public enum UITests {
     
     public var renderingViewControllers: [String: (container: UIViewController, contained: VC)] {
       return self.testCases.reduce(into: [String: (container: UIViewController, contained: VC)]()) { dict, identifier in
-        let containedVC = vc()
+        let containedVC = vc(identifier)
         let containerVC = container.container(for: containedVC)
         dict[identifier] = (container: containerVC, contained: containedVC)
       }

--- a/Tempura/UITests/ViewControllerTestCase.swift
+++ b/Tempura/UITests/ViewControllerTestCase.swift
@@ -57,7 +57,7 @@ public protocol UIViewControllerTestCase {
   /// used to provide the ViewController to test.
   /// We cannot instantiate it as we cannot require an init in the AnyViewController protocol
   /// otherwise it will require all of the subclasses to have it specified.
-  var viewController: VC { get }
+  func viewController(for testCase: String) -> VC
   
   /// configure the VC for the specified `testCase`
   /// this is typically used to manually inject the ViewModel to all the children VCs.


### PR DESCRIPTION
**Why**
There are cases in which a ViewControllerWithLocalState needs input information in order to be instantiated and those inputs depend on the test case in execution.

**Changes**
ViewControllerTestCase now requires the test case identifier in order to instantiate the viewController

**Tasks**
* [ ] Add relevant tests, if needed
* [ ] Add documentation, if needed
* [ ] Update README, if needed
* [ ] Ensure that the demo project works properly