### PR TITLE
[Feature] Public Access Level to Route Inspectables

### DIFF
--- a/Tempura/Navigation/Navigator.swift
+++ b/Tempura/Navigation/Navigator.swift
@@ -528,18 +528,20 @@ extension UIApplication {
 }
 
 /// Defines a way to inspect a UIViewController asking for the next visible UIViewController in the visible stack.
-protocol CustomRouteInspectables: class {
+public protocol CustomRouteInspectables: class {
+  /// Next view controllers to  be inspected by the router
   var nextRouteControllers: [UIViewController] { get }
 }
 
-protocol RouteInspectable: class {
+public protocol RouteInspectable: class {
+  /// Next view controller to  be inspected by the router
   var nextRouteController: UIViewController? { get }
 }
 
 /// Conformance of the UINavigationController to the RouteInspectable protocol.
 /// In a UINavigationController the next visible controller is the `topViewController`.
 extension UINavigationController: CustomRouteInspectables {
- var nextRouteControllers: [UIViewController] {
+  public var nextRouteControllers: [UIViewController] {
   var controllers: [UIViewController] = self.viewControllers
    if let presentedVC = self.presentedViewController {
      controllers.append(presentedVC)
@@ -551,7 +553,7 @@ extension UINavigationController: CustomRouteInspectables {
 /// Conformance of the UITabBarController to the RouteInspectable protocol.
 /// In a UITabBarController the next visible controller is the `selectedViewController`.
 extension UITabBarController: CustomRouteInspectables {
-  var nextRouteControllers: [UIViewController] {
+  public var nextRouteControllers: [UIViewController] {
     var controllers: [UIViewController] = []
     
     if let selectedVC = self.selectedViewController {
@@ -570,7 +572,7 @@ extension UITabBarController: CustomRouteInspectables {
 /// In a UIViewController the next visible controller is the `presentedViewController` if != nil
 /// otherwise there is no next UIViewController in the visible stack.
 extension UIViewController: RouteInspectable {
-  var nextRouteController: UIViewController? {
+  public var nextRouteController: UIViewController? {
     return self.presentedViewController
   }
 }


### PR DESCRIPTION
**Why**
This PR is needed to let custom ViewControllers that use the containment UIKit's APIs expose their Childs in order to propagate routing and presentation sources. This way they can be recognized from Tempura as Routable View Controllers.

**Changes**
Made `CustomRouteInspectables` and `RouteInspectable` public

**Tasks**
* [x] Add relevant tests, if needed
* [x] Add documentation, if needed
* [x] Update README, if needed
* [x] Ensure that the demo project works properly