### PR TITLE
Support to waiting for view to be ready after configure in ViewControllerTestCase

### DIFF
--- a/DemoTests/DemoTests.swift
+++ b/DemoTests/DemoTests.swift
@@ -37,46 +37,45 @@ class ScreenTests: XCTestCase, ViewTestCase {
   }
   
   func testAddItemScreen() {
-    self.uiTest(testCases: [
-      "add_item_01": firstTestViewModel,
-      "add_item_02": secondTestViewModel,
-      "add_item_03": thirdTestViewModel
-      ])
-    
+    self.uiTest(
+      testCases: [
+        "add_item_01": firstTestViewModel,
+        "add_item_02": secondTestViewModel,
+        "add_item_03": thirdTestViewModel
+      ]
+    )
   }
   
   func testWithHooksAndContainer() {
-    self.uiTest(testCases: [
-      "add_item_04": fourthTestViewModel
+    self.uiTest(
+      testCases: [
+        "add_item_04": fourthTestViewModel
       ],
       context: UITests.Context<AddItemView>(
         container: UITests.Container.tabBarController,
         hooks: [UITests.Hook.viewDidLoad: { view in
           view.viewController?.automaticallyAdjustsScrollViewInsets = true
-        }])
+        }]
       )
+    )
   }
-  
 }
 
 class VCTests: XCTestCase, ViewControllerTestCase {
-  
+
   var viewController: AddItemViewController {
     let store = Store<VC.V.VM.S, EmptySideEffectDependencyContainer>()
     let vc = AddItemViewController(store: store)
     return vc
   }
-  
+
   typealias VC = AddItemViewController
-  
-  func configure(vc: AddItemViewController, for testCase: String) {
-    if testCase == "firstTest" {
-      vc.rootView.model = AddItemViewModel(editingText: "ViewController test")
-    }
+
+  var firstTestVM: AddItemViewModel {
+    return AddItemViewModel(editingText: "ViewController test")
   }
-  
 
   func testVC() {
-    self.uiTest(testCases: ["firstTest"], context: UITests.VCContext<VCTests.VC>())
+    self.uiTest(testCases: ["firstTest": firstTestVM], context: UITests.VCContext<VCTests.VC>())
   }
 }

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -6,7 +6,7 @@ PODS:
   - Nimble (7.3.4)
   - PinLayout (1.8.13)
   - Quick (1.3.4)
-  - Tempura (4.3.0):
+  - Tempura (4.3.1):
     - Katana (< 4, >= 3.0)
 
 DEPENDENCIES:
@@ -38,8 +38,8 @@ SPEC CHECKSUMS:
   Nimble: 051e3d8912d40138fa5591c78594f95fb172af37
   PinLayout: e41a50260a76508b7a7fcee8955c76639adc69bc
   Quick: f4f7f063c524394c73ed93ac70983c609805d481
-  Tempura: d38c2d982864d9dbca6b11a519e8b00024d04abd
+  Tempura: adc54766491f97980bcdb3dff82a92076ed825e2
 
 PODFILE CHECKSUM: 38702d0c43f34b8b0ef75f4af24856ae2bace63d
 
-COCOAPODS: 1.8.4
+COCOAPODS: 1.9.1

--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ class ParentViewControllerUITest: XCTestCase, ViewControllerTestCase {
     
   /// execute the UI tests
   func test() {
-    self.uiTest(testCases: ["first_test"], context: context)  
+    self.uiTest(testCases: ["first_test": vm], context: context)  
   }
 }
 ```

--- a/Tempura.xcodeproj/project.pbxproj
+++ b/Tempura.xcodeproj/project.pbxproj
@@ -7,635 +7,615 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		003A74B417A6AEA0C6662521 /* UIView+snapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA3EC8FDEE4DC2807E9E72F6 /* UIView+snapshot.swift */; };
-		0B40F885055AF0ED9E7C1F05 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = E202D263AC91E57EF107CE6F /* AppState.swift */; };
-		15693720E48E2CB0D466100C /* NavigationDSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4267731146963574851DAFC7 /* NavigationDSL.swift */; };
-		16F49F1816FCF15CD5FEB646 /* NavigationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 611BBDB76D0812419D552DD7 /* NavigationProvider.swift */; };
-		173031089F26CC74607BD3BF /* TodoFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DCF78D34AC9F62FB9A391C4 /* TodoFlowLayout.swift */; };
-		1D8FB5CA9F23A630FE4730C5 /* CollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A237D4BC151C98EDE2190FD /* CollectionView.swift */; };
-		1E87CEDD2938DAA2CA3945A6 /* Pods_TempuraTesting.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 819DAD0969CDCE437CAE1FCD /* Pods_TempuraTesting.framework */; };
-		1F2B6F84C8C534759AC1695A /* NavigationUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5564081DF13E2DCA4A754F66 /* NavigationUtilities.swift */; };
-		1F34C5E853BCC8427875CAE6 /* Pods_Tempura_Demo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B57588FD20A78D0F349A51D0 /* Pods_Tempura_Demo.framework */; };
-		204DA40CDE139295A1D7FAEF /* LocalFileURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = E46224FFEBC481FA50279FEE /* LocalFileURLProtocol.swift */; };
-		24CF6B734B00054961F90E32 /* Source.swift in Sources */ = {isa = PBXBuildFile; fileRef = 164B34F6CD3CF5FEEB1FD5B3 /* Source.swift */; };
-		276D9911D025FA454429031F /* ViewControllerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A5C33BAFA60225650D6B732 /* ViewControllerSpec.swift */; };
-		2C03CB7A775BB3E56B70CDE8 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C130AE32D4EDAC409B19A41 /* UIKit.framework */; };
-		2C91DF1DDBF43118370E7843 /* LocalState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44FDD6974A9AAE917A1B84A3 /* LocalState.swift */; };
-		2D9235DD879ACBB89F363AF6 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995545296A8A7AE7E8D58645 /* AppDelegate.swift */; };
-		2EDE730F3776F9AA8930B836 /* ViewControllerTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9E1399C697BC5EEF942A3CF /* ViewControllerTestCase.swift */; };
-		3374D1553431F02B994DEED7 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D173251D097C01031976550 /* Foundation.framework */; };
-		366DFD7D1FF452047A8466BF /* UINavigationController+Completion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93A2E715A24EA2BD61386830 /* UINavigationController+Completion.swift */; };
-		374049D0F43461E632DA1521 /* ViewControllerWithLocalStateSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 184B014CD1FFE92F896DFC30 /* ViewControllerWithLocalStateSpec.swift */; };
-		3C64D84F52EB4E72AF4E819A /* Routable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36226BAB6DE2963229C3C853 /* Routable.swift */; };
-		3F6D32AC5532E7AEC948A542 /* DataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D703ADC8E96A5B1810899F7 /* DataSource.swift */; };
-		4097B99BD8B9A0C8E766B5AF /* Pods_Tempura.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1FD1C4CAC97F75A7333C7D72 /* Pods_Tempura.framework */; };
-		4155E662A6311E2174E2D6B2 /* ViewControllerContainmentSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6D5BC69D3350D1B9D715C3C /* ViewControllerContainmentSpec.swift */; };
-		43C7C5BE9F0ECA33A60D5357 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C130AE32D4EDAC409B19A41 /* UIKit.framework */; };
-		4A19838FCCEEB877D0044609 /* ViewTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AC7315440692AACA1241582 /* ViewTestCase.swift */; };
-		5479D1C638618FA05262AAE5 /* Tempura.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 22F42FAD59238FD79B9C8F38 /* Tempura.framework */; };
-		5B6CD95C28339C832D3BBE95 /* DependenciesContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F7C530C657C5D77E6F65BEA /* DependenciesContainer.swift */; };
-		5B8670DD4BB3B89665A6549F /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C130AE32D4EDAC409B19A41 /* UIKit.framework */; };
-		5FD41A4BFFF656718C3FFDAC /* ViewControllerModellableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D30ACCB127637E1AC61B810 /* ViewControllerModellableView.swift */; };
-		62640D5C3BC1265ED855FEEA /* Media.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C35DA519D7C3EAA058B502D2 /* Media.xcassets */; };
-		6442760EEE874C7B086CABDB /* RootInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077C700F068523626965D032 /* RootInstaller.swift */; };
-		6752CCE8453D2481D2D7F1B0 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C60980B218A31D97B5C740 /* ViewController.swift */; };
-		6902A60816CC51C5C8C4A814 /* Tempura.h in Headers */ = {isa = PBXBuildFile; fileRef = 1972A28C80AD0240B932B09D /* Tempura.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6D769915D9FD627582137397 /* AddItemViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329D9008F24286E2426EF844 /* AddItemViewController.swift */; };
-		7050586D8609EF254C8CED85 /* Navigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66ED1355D2D21398BF7337F8 /* Navigator.swift */; };
-		7515EBCDA7D68B3D7D2A199A /* ViewController+Containment.swift in Sources */ = {isa = PBXBuildFile; fileRef = D851DBE506E398642D668DBD /* ViewController+Containment.swift */; };
-		78907D2EA385EDCBBFB66AC3 /* AppNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F1ECA92178B8C12065DCC51 /* AppNavigation.swift */; };
-		85D0FEE49166EA8743AE82C1 /* String+Height.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D09761FFA2A62CCDD51F39 /* String+Height.swift */; };
-		8B8A3C7D229764490703D96F /* UIControl+TargetActionable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BED3CE7EC5BF238848676947 /* UIControl+TargetActionable.swift */; };
-		8DA3B85E6E17DE0D33844C26 /* ChildViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3D0BE0D35273882E284B4A /* ChildViewController.swift */; };
-		911736DF89D7F9130BE9F9D6 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D173251D097C01031976550 /* Foundation.framework */; };
-		93BD31CBA21F108FCE2481AC /* Tempura.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 22F42FAD59238FD79B9C8F38 /* Tempura.framework */; };
-		956ECE61861A11B2D5A3CE6D /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7392B93FA131402229318FA /* Models.swift */; };
-		96F280DDF3B0F102319ABD06 /* MainThread.swift in Sources */ = {isa = PBXBuildFile; fileRef = D44679922AC4BA1E55D7C898 /* MainThread.swift */; };
-		98BADAA8B128C196BBF49216 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C130AE32D4EDAC409B19A41 /* UIKit.framework */; };
-		9B839B60261ABB64C993F98A /* View.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5971D51E106452553D4E716 /* View.swift */; };
-		A3566DEA66C3D53271E8F003 /* ArchiveFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31174697A6820D732C0114F3 /* ArchiveFlowLayout.swift */; };
-		A520426AD6FC3E6FCD494B5F /* TodoCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6403AEDD3987CCB131CDA75B /* TodoCell.swift */; };
-		A93F6A743B0D6A2EE43FE3A5 /* ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDAD825046D6676944EB496D /* ViewModel.swift */; };
-		A9618DC73EC28D4EDC359FD9 /* TextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A53E2964506D66472337355C /* TextView.swift */; };
-		AC2114E0CD7993C96F55AA82 /* ConfigurableCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A0326F9B3D7FAEED676E6B8 /* ConfigurableCell.swift */; };
-		ACAF6CF7BB336F6F4C3C24D1 /* ViewModelWithState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82673FC3F68B72629551548E /* ViewModelWithState.swift */; };
-		ADED57C54A077E3F0072BB5E /* AddItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C0141E40A3CE9B56587563E /* AddItemView.swift */; };
-		AE84FFACEAF2E603D0AB60C0 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D173251D097C01031976550 /* Foundation.framework */; };
-		B2B91BE43EE3B7C95787C49A /* Pods_DemoTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7CE77389AEDC7AACE8F428B6 /* Pods_DemoTests.framework */; };
-		B7270653DE261278782C65D6 /* ItemActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCA59D1B518AE32DC1182872 /* ItemActions.swift */; };
-		BB0F6E1EF56164AD23E9CFA5 /* Tempura.h in Headers */ = {isa = PBXBuildFile; fileRef = 1972A28C80AD0240B932B09D /* Tempura.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BFD48F41F7B6860E3D3AFEF1 /* DemoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DC50F0E5AA0F6C70373EBBC /* DemoTests.swift */; };
-		C337643FD022F28ED5FB9ED4 /* String+Random.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C41635DC286DF2EF82D3C98 /* String+Random.swift */; };
-		C4226C69E7034226F0E03463 /* Demo.app in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DDA36E967230883EF4E8D53 /* Demo.app */; };
-		C750F0055E4B59378AD66A9A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D173251D097C01031976550 /* Foundation.framework */; };
-		CDB0B03F11357A63FC30F8B0 /* ModellableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36CDB9B47C276D32D3CAC4E1 /* ModellableView.swift */; };
-		CE7E561A52732025016E9AE6 /* NavigationActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94990D7E78EEC74CFB590E9F /* NavigationActions.swift */; };
-		D4E73377102DB96BB9833A18 /* ListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73A14F07C2987E4988F7B67B /* ListView.swift */; };
-		D72356D6A3B6058127B8C734 /* CGRect+Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C66C8A5601E4511780C61F5 /* CGRect+Utils.swift */; };
-		DEF460E0E92A597D1F30B2CF /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D173251D097C01031976550 /* Foundation.framework */; };
-		E35A2FE46C66A7EABCD02CDD /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C130AE32D4EDAC409B19A41 /* UIKit.framework */; };
-		EB16DE1D7508E101CA6717D2 /* UIView+Blink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0052FBB63B9EBA6800D3C448 /* UIView+Blink.swift */; };
-		ED9DDF99494335BAFC5AE3F3 /* ViewModelWithLocalState.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF4B478A00B8BC136F2637BD /* ViewModelWithLocalState.swift */; };
-		F1517BD59DCF843518DBC5D3 /* ListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 907CF40A610C54C52D1E08FA /* ListViewController.swift */; };
-		F490CAA9033845F307B1E588 /* UITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F2056966CBA35070A5D350F /* UITests.swift */; };
-		F702A8D81AFA77CA0BBFACB3 /* TempuraTesting.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C943382F9E5F42B501C4B974 /* TempuraTesting.framework */; };
-		F949F2CAB9A6E4CAE6B17320 /* Pods_TempuraTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3B0C4A6AC40DD725C533233F /* Pods_TempuraTests.framework */; };
-		FA72ED0C5378180E05494A41 /* ViewControllerWithLocalState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64719E865F059693EFEE398A /* ViewControllerWithLocalState.swift */; };
+		00C42BA58FB64F5CD18F45CA /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6467A7DF94AB92D235F11000 /* UIKit.framework */; };
+		015CABF4F89565C284547D76 /* ViewControllerWithLocalStateSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F8FF0677F29BFC2D025974C /* ViewControllerWithLocalStateSpec.swift */; };
+		0321D0FAF6D8E899E19BC911 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E9CF6D2E519EF3F9083A220 /* Foundation.framework */; };
+		0B834CAD4390EA24444D65CB /* Pods_DemoTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9053D290F6DA57F187C9CAB5 /* Pods_DemoTests.framework */; };
+		11ED3672DD93C2308ECF975C /* ListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0475499F28C825E4BB653F67 /* ListViewController.swift */; };
+		181D840EC27CF763E028B940 /* Demo.app in Frameworks */ = {isa = PBXBuildFile; fileRef = A172BDAFF26CE46F24288F53 /* Demo.app */; };
+		199CE12AEABF6F6841F26697 /* NavigationActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97B5D69383513EC07023164F /* NavigationActions.swift */; };
+		19B9EA746AA99CE348484CDF /* ViewModelWithState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1C3FE83DD5E3D3B6540B08 /* ViewModelWithState.swift */; };
+		1B7873CFDE5B8E0450C35D43 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F23238972CB06D60209082C /* AppState.swift */; };
+		2179D1576C7BF0548D1AB468 /* String+Height.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AFBEDB06D415C1374C0158C /* String+Height.swift */; };
+		28F3C14131869D683F2D2AD5 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6467A7DF94AB92D235F11000 /* UIKit.framework */; };
+		29C9308CF3FB41DA827B83DC /* ListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B717A43A2F026FCBC1BDCC0 /* ListView.swift */; };
+		2F180FA03D834DC3EEBE4B81 /* TextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C63EC6033DFD1EEE440CF3D1 /* TextView.swift */; };
+		2F83B15AB791FB34005D12A0 /* Source.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4676EB727954C1F7671D6631 /* Source.swift */; };
+		320F91337867638B2990575A /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6467A7DF94AB92D235F11000 /* UIKit.framework */; };
+		33D2785DD193C6C66362B7FF /* DataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08884FD53F3851A6A11D4534 /* DataSource.swift */; };
+		3532348AF809F51CC3D08035 /* NavigationDSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34056B8D2F55320373CBA7B2 /* NavigationDSL.swift */; };
+		35A2F0556069969E72D78AB0 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADCFE5F1C52A825FAF6A2C06 /* ViewController.swift */; };
+		3711CE4AB3008070E465AD19 /* TempuraTesting.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 85212B452152F8CEAF4E1DD7 /* TempuraTesting.framework */; };
+		372C132805B9F1A7E1025630 /* AddItemViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11C48B39DA231240985F7B20 /* AddItemViewController.swift */; };
+		3D70F2B205CAC2F647259891 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E9CF6D2E519EF3F9083A220 /* Foundation.framework */; };
+		3F13CAD64CBF9568686025C2 /* MainThread.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBBC705291F6071B88EFCDF6 /* MainThread.swift */; };
+		43CB2439637DB8BAF4B65715 /* ViewControllerWithLocalState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2016522A4E514816A0AFF7CF /* ViewControllerWithLocalState.swift */; };
+		4629A18B482DCE07453FE2FD /* UIView+snapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A4872B7196FD0A4F9872DF5 /* UIView+snapshot.swift */; };
+		47F43FC511C0EF7C39DB2A4C /* Tempura.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C6C5504CF990001D4F2C488E /* Tempura.framework */; };
+		4C5B1136319630E96A38E418 /* TodoCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2249E6C7E0ACC377D139C66C /* TodoCell.swift */; };
+		4F88720FCD65ED189EB72DCA /* ConfigurableCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA32A7BB7A56ABE9219DEA3 /* ConfigurableCell.swift */; };
+		58883F526B6B281CBA7537F6 /* RootInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66D0F14191DA8AF97FED512B /* RootInstaller.swift */; };
+		5AEA8F5BF0EDB4C13EC3C528 /* UINavigationController+Completion.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF310AE79E3273C303E9F25 /* UINavigationController+Completion.swift */; };
+		5EEE26D35B49A757AC448561 /* DependenciesContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0C302DCA2D0F8ABCDDA2A4A /* DependenciesContainer.swift */; };
+		6355D6BDBEB109E18FB4F976 /* DemoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C05310487807F0E76D63BE7A /* DemoTests.swift */; };
+		65BAF78E5152F0CD99DA8FE5 /* ViewModelWithLocalState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 052ED76A4B1BE6A346D1F889 /* ViewModelWithLocalState.swift */; };
+		66D15348EC5B9CA1ED760EED /* NavigationUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED20C414686B10B287686EF7 /* NavigationUtilities.swift */; };
+		69774EAC2CF4650914D13AA1 /* Navigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6553F3749245E6A77B1A2CE /* Navigator.swift */; };
+		6F72617AC3FBFB96CA6C09A4 /* AppNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42F8C684A37536E6B3B74F09 /* AppNavigation.swift */; };
+		71515C9E57CDF6BB6AEFA4F0 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6467A7DF94AB92D235F11000 /* UIKit.framework */; };
+		71617DC8FEC76480BF6A838D /* CollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564480F7905ABA6C7ABEB78A /* CollectionView.swift */; };
+		7B419462209110EFC6FA2BD9 /* Media.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8C08F1501913CAE489CD32FA /* Media.xcassets */; };
+		7C5327B47CF6296EBEE0D0CD /* UITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC0610F7EABA546804D12CC6 /* UITests.swift */; };
+		870041DA410ED1B272B6E574 /* TodoFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 832B7292834EF377971CFD18 /* TodoFlowLayout.swift */; };
+		8B869B1A4092A5A8D4E28515 /* Pods_TempuraTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 71785E672555D334C90B6D21 /* Pods_TempuraTests.framework */; };
+		90BB353018B3EB1633EDA7BD /* Routable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 274CA67DE7324B47E816549F /* Routable.swift */; };
+		90D61CEAE6FACF30595308A3 /* UIView+Blink.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2D9839C2FEC766B0F68351 /* UIView+Blink.swift */; };
+		9307F2FE91542A5D810743DE /* ViewController+Containment.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA1C2C60CA2509612B2132F2 /* ViewController+Containment.swift */; };
+		9DC2393D92E5B13868ED3B27 /* LocalState.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF31774251002C3C019BDCC0 /* LocalState.swift */; };
+		9F0FE9B5778B025570A83EA2 /* AddItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99C2A6826D6D5702CE9425AF /* AddItemView.swift */; };
+		9F449F3307231648B2A7C5E9 /* ViewControllerContainmentSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D896F8845D203FA13DA578FA /* ViewControllerContainmentSpec.swift */; };
+		9FCC26D967875EE7B00C589B /* UIControl+TargetActionable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA0300BD1DAED4A61415B1C6 /* UIControl+TargetActionable.swift */; };
+		A1BB3C07E945D3EA077C2E11 /* ViewTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E12738D9235E9889730AD937 /* ViewTestCase.swift */; };
+		A4EB61AB3CBDC738B871582A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E07FF0D078953E0BD860BC0F /* AppDelegate.swift */; };
+		A5BCDDD9A22A4F50FCA19DDD /* NavigationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E0AFC243F4CF887049FC725 /* NavigationProvider.swift */; };
+		A8C5C609AC89393A1848D50C /* Tempura.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E84EAA3084551A186FC9FCE /* Tempura.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AF7F9040F3B63D68DA4379EA /* CGRect+Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38605F422FAC189BF77ABA15 /* CGRect+Utils.swift */; };
+		B013888D5925B9D3946D88E1 /* String+Random.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F17A89EC1093CC17BCF2437 /* String+Random.swift */; };
+		B22D0AC0006DCA1AD2F94657 /* Pods_Tempura.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 686303F12664D029DE500692 /* Pods_Tempura.framework */; };
+		BA7C118127F2ED0579581A1F /* ModellableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D3F52EF48B81392710100B8 /* ModellableView.swift */; };
+		BBBA3F4DF7920D1E24C56696 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E9CF6D2E519EF3F9083A220 /* Foundation.framework */; };
+		BCA87C405BCF91B0ED782D0F /* Tempura.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E84EAA3084551A186FC9FCE /* Tempura.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BE03606634C50410E983C063 /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E07BCD0045E2CA10541C7BD /* Models.swift */; };
+		CD81D824EF5B57F1243FC4CF /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E9CF6D2E519EF3F9083A220 /* Foundation.framework */; };
+		CF723FCB8BBED7832A772C84 /* ViewControllerTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0ED2D46724416E9CF59E5A0 /* ViewControllerTestCase.swift */; };
+		D496137C8FCCCEF39E335913 /* LocalFileURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB4FFEE2D12C92CE1307E6FB /* LocalFileURLProtocol.swift */; };
+		D758867F54D06CEFEFD1301F /* ItemActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69C6CB90C6EE139CCF5B838D /* ItemActions.swift */; };
+		D96E0FCAB9DB44F99BF004ED /* Tempura.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C6C5504CF990001D4F2C488E /* Tempura.framework */; };
+		E02D3CAA7368B3E147B60EAE /* ChildViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40068B61E8736ECDCF8AC956 /* ChildViewController.swift */; };
+		E486A7A39CBB5498C760A511 /* Pods_TempuraTesting.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00D800CCEF057834DC16C77D /* Pods_TempuraTesting.framework */; };
+		E497E22BB8ADB674E592B1C8 /* ViewControllerModellableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53A54145F093C68E64B56F7F /* ViewControllerModellableView.swift */; };
+		E685F250D57C912C5A1164CD /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6467A7DF94AB92D235F11000 /* UIKit.framework */; };
+		ED8FB2320F3565D7925ABDB9 /* View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DE04F938EABC169EA425F72 /* View.swift */; };
+		F60BEC64669EAD92990451F3 /* ArchiveFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = D525DF8AF883113A2D0239A5 /* ArchiveFlowLayout.swift */; };
+		F63EB2279AF3CF2D84A7164D /* Pods_Tempura_Demo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2AAFBDD6CB61018695C145DD /* Pods_Tempura_Demo.framework */; };
+		F972509E112CE71BDA9CE893 /* ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9487708B9F3798AA35DDAE68 /* ViewModel.swift */; };
+		FEC598245CAC074324213E83 /* ViewControllerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34EEF890908267AFCE0F47A4 /* ViewControllerSpec.swift */; };
+		FF04AF3EBA8020B4A858CF84 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E9CF6D2E519EF3F9083A220 /* Foundation.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		0079F4AE23BE7BCA0FBB1B39 /* PBXContainerItemProxy */ = {
+		055A11CFA7E90E7C5D076BDF /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 8EC533182C3CFE067090F556 /* Project object */;
+			containerPortal = 492FE962CD1288564FD0DA53 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 9A7B2C2C4784A31CB213B287;
-			remoteInfo = Tempura;
-		};
-		3E94D9AB36086D71D1FD3806 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 8EC533182C3CFE067090F556 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = F133CD648D5FA1083759D479;
+			remoteGlobalIDString = 2DBFEB5C4518FCDC7132F05C;
 			remoteInfo = Demo;
 		};
-		9E17CB8A8DE47C8A983B66F4 /* PBXContainerItemProxy */ = {
+		21BB65CD083898EAF5D3ABB1 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 8EC533182C3CFE067090F556 /* Project object */;
+			containerPortal = 492FE962CD1288564FD0DA53 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 9A7B2C2C4784A31CB213B287;
+			remoteGlobalIDString = E83AC9A1F08F0A742FE602FF;
+			remoteInfo = TempuraTesting;
+		};
+		B4413295C8E51889E0DCF179 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 492FE962CD1288564FD0DA53 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 8B7292CC2417BBB996CFC789;
 			remoteInfo = Tempura;
 		};
-		AA4FDDB9F87D0DB5C9495E3F /* PBXContainerItemProxy */ = {
+		CE0BF864545BEDEBECEC8A58 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 8EC533182C3CFE067090F556 /* Project object */;
+			containerPortal = 492FE962CD1288564FD0DA53 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = C3B2B96BE82BCDAED4C2C527;
-			remoteInfo = TempuraTesting;
+			remoteGlobalIDString = 8B7292CC2417BBB996CFC789;
+			remoteInfo = Tempura;
 		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		0052FBB63B9EBA6800D3C448 /* UIView+Blink.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "UIView+Blink.swift"; sourceTree = "<group>"; };
-		03207435C27B3BA015183220 /* DemoTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DemoTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		04C60980B218A31D97B5C740 /* ViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
-		077C700F068523626965D032 /* RootInstaller.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RootInstaller.swift; sourceTree = "<group>"; };
-		0D79233B0CEED31350194F1C /* Pods-Tempura.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tempura.release.xcconfig"; path = "Target Support Files/Pods-Tempura/Pods-Tempura.release.xcconfig"; sourceTree = "<group>"; };
-		0F1ECA92178B8C12065DCC51 /* AppNavigation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppNavigation.swift; sourceTree = "<group>"; };
-		1072A73394C9DE763373F81E /* Pods-Tempura.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tempura.debug.xcconfig"; path = "Target Support Files/Pods-Tempura/Pods-Tempura.debug.xcconfig"; sourceTree = "<group>"; };
-		164B34F6CD3CF5FEEB1FD5B3 /* Source.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Source.swift; sourceTree = "<group>"; };
-		184B014CD1FFE92F896DFC30 /* ViewControllerWithLocalStateSpec.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewControllerWithLocalStateSpec.swift; sourceTree = "<group>"; };
-		1972A28C80AD0240B932B09D /* Tempura.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = Tempura.h; sourceTree = "<group>"; };
-		1D173251D097C01031976550 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.2.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		1DDA36E967230883EF4E8D53 /* Demo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Demo.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		1FD1C4CAC97F75A7333C7D72 /* Pods_Tempura.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Tempura.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		20D09761FFA2A62CCDD51F39 /* String+Height.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "String+Height.swift"; sourceTree = "<group>"; };
-		22F42FAD59238FD79B9C8F38 /* Tempura.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Tempura.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		2C0141E40A3CE9B56587563E /* AddItemView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AddItemView.swift; sourceTree = "<group>"; };
-		2F2056966CBA35070A5D350F /* UITests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UITests.swift; sourceTree = "<group>"; };
-		31174697A6820D732C0114F3 /* ArchiveFlowLayout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ArchiveFlowLayout.swift; sourceTree = "<group>"; };
-		329D9008F24286E2426EF844 /* AddItemViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AddItemViewController.swift; sourceTree = "<group>"; };
-		36226BAB6DE2963229C3C853 /* Routable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Routable.swift; sourceTree = "<group>"; };
-		36CDB9B47C276D32D3CAC4E1 /* ModellableView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ModellableView.swift; sourceTree = "<group>"; };
-		3B0C4A6AC40DD725C533233F /* Pods_TempuraTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TempuraTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		3C41635DC286DF2EF82D3C98 /* String+Random.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "String+Random.swift"; sourceTree = "<group>"; };
-		3C66C8A5601E4511780C61F5 /* CGRect+Utils.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "CGRect+Utils.swift"; sourceTree = "<group>"; };
-		3E85CCD29540E3DEE2DA87F0 /* Pods-Tempura-Demo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tempura-Demo.debug.xcconfig"; path = "Target Support Files/Pods-Tempura-Demo/Pods-Tempura-Demo.debug.xcconfig"; sourceTree = "<group>"; };
-		3F7C530C657C5D77E6F65BEA /* DependenciesContainer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DependenciesContainer.swift; sourceTree = "<group>"; };
-		4267731146963574851DAFC7 /* NavigationDSL.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NavigationDSL.swift; sourceTree = "<group>"; };
-		44FDD6974A9AAE917A1B84A3 /* LocalState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LocalState.swift; sourceTree = "<group>"; };
-		4A0326F9B3D7FAEED676E6B8 /* ConfigurableCell.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConfigurableCell.swift; sourceTree = "<group>"; };
-		4D30ACCB127637E1AC61B810 /* ViewControllerModellableView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewControllerModellableView.swift; sourceTree = "<group>"; };
-		5564081DF13E2DCA4A754F66 /* NavigationUtilities.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NavigationUtilities.swift; sourceTree = "<group>"; };
-		569E390CCB8B0146A15D1AEB /* Pods-TempuraTesting.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TempuraTesting.debug.xcconfig"; path = "Target Support Files/Pods-TempuraTesting/Pods-TempuraTesting.debug.xcconfig"; sourceTree = "<group>"; };
-		5A237D4BC151C98EDE2190FD /* CollectionView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CollectionView.swift; sourceTree = "<group>"; };
-		5AFC07783E89FF67C96D2EB4 /* Pods-Tempura-Demo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tempura-Demo.release.xcconfig"; path = "Target Support Files/Pods-Tempura-Demo/Pods-Tempura-Demo.release.xcconfig"; sourceTree = "<group>"; };
-		5C130AE32D4EDAC409B19A41 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.2.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
-		5DCF78D34AC9F62FB9A391C4 /* TodoFlowLayout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TodoFlowLayout.swift; sourceTree = "<group>"; };
-		611BBDB76D0812419D552DD7 /* NavigationProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NavigationProvider.swift; sourceTree = "<group>"; };
-		6403AEDD3987CCB131CDA75B /* TodoCell.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TodoCell.swift; sourceTree = "<group>"; };
-		64719E865F059693EFEE398A /* ViewControllerWithLocalState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewControllerWithLocalState.swift; sourceTree = "<group>"; };
-		66ED1355D2D21398BF7337F8 /* Navigator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Navigator.swift; sourceTree = "<group>"; };
-		73A14F07C2987E4988F7B67B /* ListView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ListView.swift; sourceTree = "<group>"; };
-		7A5C33BAFA60225650D6B732 /* ViewControllerSpec.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewControllerSpec.swift; sourceTree = "<group>"; };
-		7CE77389AEDC7AACE8F428B6 /* Pods_DemoTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_DemoTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		7F8048FD19E805306CFC1017 /* Pods-TempuraTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TempuraTests.release.xcconfig"; path = "Target Support Files/Pods-TempuraTests/Pods-TempuraTests.release.xcconfig"; sourceTree = "<group>"; };
-		819DAD0969CDCE437CAE1FCD /* Pods_TempuraTesting.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TempuraTesting.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		82673FC3F68B72629551548E /* ViewModelWithState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewModelWithState.swift; sourceTree = "<group>"; };
-		8DC50F0E5AA0F6C70373EBBC /* DemoTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DemoTests.swift; sourceTree = "<group>"; };
-		907CF40A610C54C52D1E08FA /* ListViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ListViewController.swift; sourceTree = "<group>"; };
-		93A2E715A24EA2BD61386830 /* UINavigationController+Completion.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "UINavigationController+Completion.swift"; sourceTree = "<group>"; };
-		94990D7E78EEC74CFB590E9F /* NavigationActions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NavigationActions.swift; sourceTree = "<group>"; };
-		995545296A8A7AE7E8D58645 /* AppDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		9AC7315440692AACA1241582 /* ViewTestCase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewTestCase.swift; sourceTree = "<group>"; };
-		9D703ADC8E96A5B1810899F7 /* DataSource.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DataSource.swift; sourceTree = "<group>"; };
-		A53E2964506D66472337355C /* TextView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TextView.swift; sourceTree = "<group>"; };
-		AF4B478A00B8BC136F2637BD /* ViewModelWithLocalState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewModelWithLocalState.swift; sourceTree = "<group>"; };
-		B57588FD20A78D0F349A51D0 /* Pods_Tempura_Demo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Tempura_Demo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		B9E1399C697BC5EEF942A3CF /* ViewControllerTestCase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewControllerTestCase.swift; sourceTree = "<group>"; };
-		BCA59D1B518AE32DC1182872 /* ItemActions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ItemActions.swift; sourceTree = "<group>"; };
-		BED3CE7EC5BF238848676947 /* UIControl+TargetActionable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "UIControl+TargetActionable.swift"; sourceTree = "<group>"; };
-		C35DA519D7C3EAA058B502D2 /* Media.xcassets */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder.assetcatalog; path = Media.xcassets; sourceTree = "<group>"; };
-		C5971D51E106452553D4E716 /* View.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = View.swift; sourceTree = "<group>"; };
-		C8EA6B9D00FA578ACCF03D70 /* Pods-DemoTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DemoTests.debug.xcconfig"; path = "Target Support Files/Pods-DemoTests/Pods-DemoTests.debug.xcconfig"; sourceTree = "<group>"; };
-		C943382F9E5F42B501C4B974 /* TempuraTesting.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TempuraTesting.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		CA3EC8FDEE4DC2807E9E72F6 /* UIView+snapshot.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "UIView+snapshot.swift"; sourceTree = "<group>"; };
-		CBD200BDEA2EBF67BD1164F3 /* TempuraTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TempuraTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		CDAD825046D6676944EB496D /* ViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewModel.swift; sourceTree = "<group>"; };
-		D44679922AC4BA1E55D7C898 /* MainThread.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MainThread.swift; sourceTree = "<group>"; };
-		D851DBE506E398642D668DBD /* ViewController+Containment.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ViewController+Containment.swift"; sourceTree = "<group>"; };
-		DE3D0BE0D35273882E284B4A /* ChildViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ChildViewController.swift; sourceTree = "<group>"; };
-		E202D263AC91E57EF107CE6F /* AppState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
-		E46224FFEBC481FA50279FEE /* LocalFileURLProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LocalFileURLProtocol.swift; sourceTree = "<group>"; };
-		E7392B93FA131402229318FA /* Models.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Models.swift; sourceTree = "<group>"; };
-		F29DBB122D76B66BE9B82FEF /* Pods-DemoTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DemoTests.release.xcconfig"; path = "Target Support Files/Pods-DemoTests/Pods-DemoTests.release.xcconfig"; sourceTree = "<group>"; };
-		F6D5BC69D3350D1B9D715C3C /* ViewControllerContainmentSpec.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewControllerContainmentSpec.swift; sourceTree = "<group>"; };
-		F70BA8019F66F30D9FFAB9F0 /* Pods-TempuraTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TempuraTests.debug.xcconfig"; path = "Target Support Files/Pods-TempuraTests/Pods-TempuraTests.debug.xcconfig"; sourceTree = "<group>"; };
-		F86D79A5717CA3800CF3EAC9 /* Pods-TempuraTesting.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TempuraTesting.release.xcconfig"; path = "Target Support Files/Pods-TempuraTesting/Pods-TempuraTesting.release.xcconfig"; sourceTree = "<group>"; };
+		00D800CCEF057834DC16C77D /* Pods_TempuraTesting.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TempuraTesting.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		0475499F28C825E4BB653F67 /* ListViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ListViewController.swift; sourceTree = "<group>"; };
+		052ED76A4B1BE6A346D1F889 /* ViewModelWithLocalState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewModelWithLocalState.swift; sourceTree = "<group>"; };
+		08884FD53F3851A6A11D4534 /* DataSource.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DataSource.swift; sourceTree = "<group>"; };
+		0B717A43A2F026FCBC1BDCC0 /* ListView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ListView.swift; sourceTree = "<group>"; };
+		0F23238972CB06D60209082C /* AppState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
+		0F8FF0677F29BFC2D025974C /* ViewControllerWithLocalStateSpec.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewControllerWithLocalStateSpec.swift; sourceTree = "<group>"; };
+		11C48B39DA231240985F7B20 /* AddItemViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AddItemViewController.swift; sourceTree = "<group>"; };
+		1F17A89EC1093CC17BCF2437 /* String+Random.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "String+Random.swift"; sourceTree = "<group>"; };
+		1F63CDF7589268E03735FC86 /* Pods-Tempura-Demo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tempura-Demo.debug.xcconfig"; path = "Target Support Files/Pods-Tempura-Demo/Pods-Tempura-Demo.debug.xcconfig"; sourceTree = "<group>"; };
+		2016522A4E514816A0AFF7CF /* ViewControllerWithLocalState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewControllerWithLocalState.swift; sourceTree = "<group>"; };
+		2249E6C7E0ACC377D139C66C /* TodoCell.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TodoCell.swift; sourceTree = "<group>"; };
+		274CA67DE7324B47E816549F /* Routable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Routable.swift; sourceTree = "<group>"; };
+		2AAFBDD6CB61018695C145DD /* Pods_Tempura_Demo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Tempura_Demo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		2DF35A7BE1C7E9405DDED824 /* Pods-Tempura.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tempura.release.xcconfig"; path = "Target Support Files/Pods-Tempura/Pods-Tempura.release.xcconfig"; sourceTree = "<group>"; };
+		34056B8D2F55320373CBA7B2 /* NavigationDSL.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NavigationDSL.swift; sourceTree = "<group>"; };
+		34EEF890908267AFCE0F47A4 /* ViewControllerSpec.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewControllerSpec.swift; sourceTree = "<group>"; };
+		38605F422FAC189BF77ABA15 /* CGRect+Utils.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "CGRect+Utils.swift"; sourceTree = "<group>"; };
+		3A4872B7196FD0A4F9872DF5 /* UIView+snapshot.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "UIView+snapshot.swift"; sourceTree = "<group>"; };
+		3E9CF6D2E519EF3F9083A220 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.2.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		40068B61E8736ECDCF8AC956 /* ChildViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ChildViewController.swift; sourceTree = "<group>"; };
+		42F8C684A37536E6B3B74F09 /* AppNavigation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppNavigation.swift; sourceTree = "<group>"; };
+		4676EB727954C1F7671D6631 /* Source.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Source.swift; sourceTree = "<group>"; };
+		4DE04F938EABC169EA425F72 /* View.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = View.swift; sourceTree = "<group>"; };
+		4E07BCD0045E2CA10541C7BD /* Models.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Models.swift; sourceTree = "<group>"; };
+		50E2E726E7A8892EDC0D6F46 /* TempuraTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TempuraTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		51227F140EC83F6211D94270 /* Pods-TempuraTesting.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TempuraTesting.debug.xcconfig"; path = "Target Support Files/Pods-TempuraTesting/Pods-TempuraTesting.debug.xcconfig"; sourceTree = "<group>"; };
+		53A54145F093C68E64B56F7F /* ViewControllerModellableView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewControllerModellableView.swift; sourceTree = "<group>"; };
+		564480F7905ABA6C7ABEB78A /* CollectionView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CollectionView.swift; sourceTree = "<group>"; };
+		568D2512A23AABAAC553ED39 /* Pods-Tempura.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tempura.debug.xcconfig"; path = "Target Support Files/Pods-Tempura/Pods-Tempura.debug.xcconfig"; sourceTree = "<group>"; };
+		5DF746EB692CE56F05B62DDE /* Pods-DemoTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DemoTests.debug.xcconfig"; path = "Target Support Files/Pods-DemoTests/Pods-DemoTests.debug.xcconfig"; sourceTree = "<group>"; };
+		5F8E31565B611C17FF9FC202 /* Pods-Tempura-Demo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tempura-Demo.release.xcconfig"; path = "Target Support Files/Pods-Tempura-Demo/Pods-Tempura-Demo.release.xcconfig"; sourceTree = "<group>"; };
+		6467A7DF94AB92D235F11000 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.2.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
+		66D0F14191DA8AF97FED512B /* RootInstaller.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RootInstaller.swift; sourceTree = "<group>"; };
+		686303F12664D029DE500692 /* Pods_Tempura.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Tempura.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		69C6CB90C6EE139CCF5B838D /* ItemActions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ItemActions.swift; sourceTree = "<group>"; };
+		6E0AFC243F4CF887049FC725 /* NavigationProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NavigationProvider.swift; sourceTree = "<group>"; };
+		71785E672555D334C90B6D21 /* Pods_TempuraTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TempuraTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		7D3F52EF48B81392710100B8 /* ModellableView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ModellableView.swift; sourceTree = "<group>"; };
+		832B7292834EF377971CFD18 /* TodoFlowLayout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TodoFlowLayout.swift; sourceTree = "<group>"; };
+		85212B452152F8CEAF4E1DD7 /* TempuraTesting.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TempuraTesting.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		8A1C3FE83DD5E3D3B6540B08 /* ViewModelWithState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewModelWithState.swift; sourceTree = "<group>"; };
+		8AFBEDB06D415C1374C0158C /* String+Height.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "String+Height.swift"; sourceTree = "<group>"; };
+		8C08F1501913CAE489CD32FA /* Media.xcassets */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder.assetcatalog; path = Media.xcassets; sourceTree = "<group>"; };
+		8E84EAA3084551A186FC9FCE /* Tempura.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = Tempura.h; sourceTree = "<group>"; };
+		9053D290F6DA57F187C9CAB5 /* Pods_DemoTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_DemoTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		9487708B9F3798AA35DDAE68 /* ViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewModel.swift; sourceTree = "<group>"; };
+		97B5D69383513EC07023164F /* NavigationActions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NavigationActions.swift; sourceTree = "<group>"; };
+		997D0064D0818DC876B9BE91 /* Pods-TempuraTesting.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TempuraTesting.release.xcconfig"; path = "Target Support Files/Pods-TempuraTesting/Pods-TempuraTesting.release.xcconfig"; sourceTree = "<group>"; };
+		99C2A6826D6D5702CE9425AF /* AddItemView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AddItemView.swift; sourceTree = "<group>"; };
+		A0C302DCA2D0F8ABCDDA2A4A /* DependenciesContainer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DependenciesContainer.swift; sourceTree = "<group>"; };
+		A172BDAFF26CE46F24288F53 /* Demo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Demo.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		A6553F3749245E6A77B1A2CE /* Navigator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Navigator.swift; sourceTree = "<group>"; };
+		ADCFE5F1C52A825FAF6A2C06 /* ViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		B92584C52ECB6EA3F82EABFE /* Pods-DemoTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DemoTests.release.xcconfig"; path = "Target Support Files/Pods-DemoTests/Pods-DemoTests.release.xcconfig"; sourceTree = "<group>"; };
+		BA0300BD1DAED4A61415B1C6 /* UIControl+TargetActionable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "UIControl+TargetActionable.swift"; sourceTree = "<group>"; };
+		BC0610F7EABA546804D12CC6 /* UITests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UITests.swift; sourceTree = "<group>"; };
+		BF31774251002C3C019BDCC0 /* LocalState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LocalState.swift; sourceTree = "<group>"; };
+		BFF310AE79E3273C303E9F25 /* UINavigationController+Completion.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "UINavigationController+Completion.swift"; sourceTree = "<group>"; };
+		C05310487807F0E76D63BE7A /* DemoTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DemoTests.swift; sourceTree = "<group>"; };
+		C0ED2D46724416E9CF59E5A0 /* ViewControllerTestCase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewControllerTestCase.swift; sourceTree = "<group>"; };
+		C63EC6033DFD1EEE440CF3D1 /* TextView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TextView.swift; sourceTree = "<group>"; };
+		C6C5504CF990001D4F2C488E /* Tempura.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Tempura.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C9DE409834C1C87B37A02470 /* Pods-TempuraTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TempuraTests.debug.xcconfig"; path = "Target Support Files/Pods-TempuraTests/Pods-TempuraTests.debug.xcconfig"; sourceTree = "<group>"; };
+		CA1C2C60CA2509612B2132F2 /* ViewController+Containment.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ViewController+Containment.swift"; sourceTree = "<group>"; };
+		CC2D9839C2FEC766B0F68351 /* UIView+Blink.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "UIView+Blink.swift"; sourceTree = "<group>"; };
+		CEA32A7BB7A56ABE9219DEA3 /* ConfigurableCell.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConfigurableCell.swift; sourceTree = "<group>"; };
+		D525DF8AF883113A2D0239A5 /* ArchiveFlowLayout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ArchiveFlowLayout.swift; sourceTree = "<group>"; };
+		D896F8845D203FA13DA578FA /* ViewControllerContainmentSpec.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewControllerContainmentSpec.swift; sourceTree = "<group>"; };
+		DB4FFEE2D12C92CE1307E6FB /* LocalFileURLProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LocalFileURLProtocol.swift; sourceTree = "<group>"; };
+		DBBC705291F6071B88EFCDF6 /* MainThread.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MainThread.swift; sourceTree = "<group>"; };
+		E07FF0D078953E0BD860BC0F /* AppDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		E12738D9235E9889730AD937 /* ViewTestCase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewTestCase.swift; sourceTree = "<group>"; };
+		ED20C414686B10B287686EF7 /* NavigationUtilities.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NavigationUtilities.swift; sourceTree = "<group>"; };
+		F2BC763CC1F86172C36B3C5C /* DemoTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DemoTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		FDB93D95E96253641C5A462A /* Pods-TempuraTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TempuraTests.release.xcconfig"; path = "Target Support Files/Pods-TempuraTests/Pods-TempuraTests.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		35518798597B8C933686910D /* Frameworks */ = {
+		052E30597693BF6A5445C25F /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C4226C69E7034226F0E03463 /* Demo.app in Frameworks */,
-				F702A8D81AFA77CA0BBFACB3 /* TempuraTesting.framework in Frameworks */,
-				911736DF89D7F9130BE9F9D6 /* Foundation.framework in Frameworks */,
-				98BADAA8B128C196BBF49216 /* UIKit.framework in Frameworks */,
-				B2B91BE43EE3B7C95787C49A /* Pods_DemoTests.framework in Frameworks */,
+				181D840EC27CF763E028B940 /* Demo.app in Frameworks */,
+				3711CE4AB3008070E465AD19 /* TempuraTesting.framework in Frameworks */,
+				0321D0FAF6D8E899E19BC911 /* Foundation.framework in Frameworks */,
+				320F91337867638B2990575A /* UIKit.framework in Frameworks */,
+				0B834CAD4390EA24444D65CB /* Pods_DemoTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		3565D5C367159A3C3BD55263 /* Frameworks */ = {
+		40C46026C0129953FA335A83 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				93BD31CBA21F108FCE2481AC /* Tempura.framework in Frameworks */,
-				3374D1553431F02B994DEED7 /* Foundation.framework in Frameworks */,
-				2C03CB7A775BB3E56B70CDE8 /* UIKit.framework in Frameworks */,
-				F949F2CAB9A6E4CAE6B17320 /* Pods_TempuraTests.framework in Frameworks */,
+				D96E0FCAB9DB44F99BF004ED /* Tempura.framework in Frameworks */,
+				BBBA3F4DF7920D1E24C56696 /* Foundation.framework in Frameworks */,
+				28F3C14131869D683F2D2AD5 /* UIKit.framework in Frameworks */,
+				8B869B1A4092A5A8D4E28515 /* Pods_TempuraTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		762686097E1040E223C59852 /* Frameworks */ = {
+		43D49F23D08A1F9CF014F360 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5479D1C638618FA05262AAE5 /* Tempura.framework in Frameworks */,
-				DEF460E0E92A597D1F30B2CF /* Foundation.framework in Frameworks */,
-				E35A2FE46C66A7EABCD02CDD /* UIKit.framework in Frameworks */,
-				1F34C5E853BCC8427875CAE6 /* Pods_Tempura_Demo.framework in Frameworks */,
+				47F43FC511C0EF7C39DB2A4C /* Tempura.framework in Frameworks */,
+				3D70F2B205CAC2F647259891 /* Foundation.framework in Frameworks */,
+				E685F250D57C912C5A1164CD /* UIKit.framework in Frameworks */,
+				F63EB2279AF3CF2D84A7164D /* Pods_Tempura_Demo.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		8478B7BA0BA582B57D5F2951 /* Frameworks */ = {
+		CF6046519C6763C9BC9C5C08 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C750F0055E4B59378AD66A9A /* Foundation.framework in Frameworks */,
-				5B8670DD4BB3B89665A6549F /* UIKit.framework in Frameworks */,
-				1E87CEDD2938DAA2CA3945A6 /* Pods_TempuraTesting.framework in Frameworks */,
+				CD81D824EF5B57F1243FC4CF /* Foundation.framework in Frameworks */,
+				00C42BA58FB64F5CD18F45CA /* UIKit.framework in Frameworks */,
+				E486A7A39CBB5498C760A511 /* Pods_TempuraTesting.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		ECD81D2555899EAB13A3A2BE /* Frameworks */ = {
+		FB4573F305502A1B65310FA5 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				AE84FFACEAF2E603D0AB60C0 /* Foundation.framework in Frameworks */,
-				43C7C5BE9F0ECA33A60D5357 /* UIKit.framework in Frameworks */,
-				4097B99BD8B9A0C8E766B5AF /* Pods_Tempura.framework in Frameworks */,
+				FF04AF3EBA8020B4A858CF84 /* Foundation.framework in Frameworks */,
+				71515C9E57CDF6BB6AEFA4F0 /* UIKit.framework in Frameworks */,
+				B22D0AC0006DCA1AD2F94657 /* Pods_Tempura.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		0A2AB5A994B868D3D198342B /* Utilities */ = {
+		113B415BBA6E6210F21036F6 /* ListScreen */ = {
 			isa = PBXGroup;
 			children = (
-				D44679922AC4BA1E55D7C898 /* MainThread.swift */,
-			);
-			name = Utilities;
-			path = Utilities;
-			sourceTree = "<group>";
-		};
-		22187D0F5197DABDFDD21723 /* AddItemScreen */ = {
-			isa = PBXGroup;
-			children = (
-				A11A7BCA2DC4D9DBFFF1306B /* Subviews */,
-				2C0141E40A3CE9B56587563E /* AddItemView.swift */,
-				329D9008F24286E2426EF844 /* AddItemViewController.swift */,
-			);
-			name = AddItemScreen;
-			path = AddItemScreen;
-			sourceTree = "<group>";
-		};
-		342DDB226674F5396F52B853 /* Core */ = {
-			isa = PBXGroup;
-			children = (
-				04C60980B218A31D97B5C740 /* ViewController.swift */,
-				C5971D51E106452553D4E716 /* View.swift */,
-				82673FC3F68B72629551548E /* ViewModelWithState.swift */,
-				36CDB9B47C276D32D3CAC4E1 /* ModellableView.swift */,
-				AF4B478A00B8BC136F2637BD /* ViewModelWithLocalState.swift */,
-				44FDD6974A9AAE917A1B84A3 /* LocalState.swift */,
-				CDAD825046D6676944EB496D /* ViewModel.swift */,
-				4D30ACCB127637E1AC61B810 /* ViewControllerModellableView.swift */,
-				64719E865F059693EFEE398A /* ViewControllerWithLocalState.swift */,
-				D851DBE506E398642D668DBD /* ViewController+Containment.swift */,
-			);
-			name = Core;
-			path = Core;
-			sourceTree = "<group>";
-		};
-		435A4657730A540501BB0086 /* Subviews */ = {
-			isa = PBXGroup;
-			children = (
-				31174697A6820D732C0114F3 /* ArchiveFlowLayout.swift */,
-				6403AEDD3987CCB131CDA75B /* TodoCell.swift */,
-				5DCF78D34AC9F62FB9A391C4 /* TodoFlowLayout.swift */,
-			);
-			name = Subviews;
-			path = Subviews;
-			sourceTree = "<group>";
-		};
-		46B3F0C5FBAF55F9CDC085F9 /* Tempura */ = {
-			isa = PBXGroup;
-			children = (
-				342DDB226674F5396F52B853 /* Core */,
-				DD2A773F944A89F1F1496F66 /* Navigation */,
-				0A2AB5A994B868D3D198342B /* Utilities */,
-				8D210A56029AE558547CFC51 /* UITests */,
-				E27B94DF3BF41203FDDBDA8C /* SupportingFiles */,
-			);
-			name = Tempura;
-			path = Tempura;
-			sourceTree = "<group>";
-		};
-		584F31C62524439AF2DEBAE9 = {
-			isa = PBXGroup;
-			children = (
-				CDACA981441DBC60BA6B6065 /* Products */,
-				74E07E6BC052C901A396F51F /* Frameworks */,
-				7CAE0F10FD257B249FC0B3F2 /* TempuraTests */,
-				46B3F0C5FBAF55F9CDC085F9 /* Tempura */,
-				AEFA00A76C63B755867294DC /* DemoTests */,
-				8A60C4D58F4FEC199CEEB6C6 /* Demo */,
-				5EEAF698D76C5CDDD68237AF /* Pods */,
-			);
-			sourceTree = "<group>";
-		};
-		5AD2AD3801E1145FF2FD2872 /* Utilities */ = {
-			isa = PBXGroup;
-			children = (
-				BED3CE7EC5BF238848676947 /* UIControl+TargetActionable.swift */,
-				3C41635DC286DF2EF82D3C98 /* String+Random.swift */,
-				CE50A14BB02040C75E6353F3 /* CollectionView */,
-				3C66C8A5601E4511780C61F5 /* CGRect+Utils.swift */,
-				0052FBB63B9EBA6800D3C448 /* UIView+Blink.swift */,
-				20D09761FFA2A62CCDD51F39 /* String+Height.swift */,
-			);
-			name = Utilities;
-			path = Utilities;
-			sourceTree = "<group>";
-		};
-		5EEAF698D76C5CDDD68237AF /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				C8EA6B9D00FA578ACCF03D70 /* Pods-DemoTests.debug.xcconfig */,
-				F29DBB122D76B66BE9B82FEF /* Pods-DemoTests.release.xcconfig */,
-				1072A73394C9DE763373F81E /* Pods-Tempura.debug.xcconfig */,
-				0D79233B0CEED31350194F1C /* Pods-Tempura.release.xcconfig */,
-				3E85CCD29540E3DEE2DA87F0 /* Pods-Tempura-Demo.debug.xcconfig */,
-				5AFC07783E89FF67C96D2EB4 /* Pods-Tempura-Demo.release.xcconfig */,
-				569E390CCB8B0146A15D1AEB /* Pods-TempuraTesting.debug.xcconfig */,
-				F86D79A5717CA3800CF3EAC9 /* Pods-TempuraTesting.release.xcconfig */,
-				F70BA8019F66F30D9FFAB9F0 /* Pods-TempuraTests.debug.xcconfig */,
-				7F8048FD19E805306CFC1017 /* Pods-TempuraTests.release.xcconfig */,
-			);
-			name = Pods;
-			path = Pods;
-			sourceTree = "<group>";
-		};
-		74E07E6BC052C901A396F51F /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				94F1688C69043B613C7BE9DE /* iOS */,
-				7CE77389AEDC7AACE8F428B6 /* Pods_DemoTests.framework */,
-				1FD1C4CAC97F75A7333C7D72 /* Pods_Tempura.framework */,
-				B57588FD20A78D0F349A51D0 /* Pods_Tempura_Demo.framework */,
-				819DAD0969CDCE437CAE1FCD /* Pods_TempuraTesting.framework */,
-				3B0C4A6AC40DD725C533233F /* Pods_TempuraTests.framework */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		7C0DD399437C5406597F727A /* Dependencies */ = {
-			isa = PBXGroup;
-			children = (
-				3F7C530C657C5D77E6F65BEA /* DependenciesContainer.swift */,
-			);
-			name = Dependencies;
-			path = Dependencies;
-			sourceTree = "<group>";
-		};
-		7CAE0F10FD257B249FC0B3F2 /* TempuraTests */ = {
-			isa = PBXGroup;
-			children = (
-				7A5C33BAFA60225650D6B732 /* ViewControllerSpec.swift */,
-				F6D5BC69D3350D1B9D715C3C /* ViewControllerContainmentSpec.swift */,
-				184B014CD1FFE92F896DFC30 /* ViewControllerWithLocalStateSpec.swift */,
-			);
-			name = TempuraTests;
-			path = TempuraTests;
-			sourceTree = "<group>";
-		};
-		8A60C4D58F4FEC199CEEB6C6 /* Demo */ = {
-			isa = PBXGroup;
-			children = (
-				8D60BF094FDC6EF8DB471575 /* UI */,
-				F93EA14FC3FA4C61D2D7380E /* Navigation */,
-				7C0DD399437C5406597F727A /* Dependencies */,
-				D51A7391986EEB39473CBBDB /* State */,
-				5AD2AD3801E1145FF2FD2872 /* Utilities */,
-				D7D53C5D07F3B9EF01E37223 /* Actions */,
-				A5C997FDBDFD8F9088B3D165 /* Application */,
-				E4B051AA8A6A186473F9C193 /* Resources */,
-			);
-			name = Demo;
-			path = Demo;
-			sourceTree = "<group>";
-		};
-		8D210A56029AE558547CFC51 /* UITests */ = {
-			isa = PBXGroup;
-			children = (
-				2F2056966CBA35070A5D350F /* UITests.swift */,
-				E46224FFEBC481FA50279FEE /* LocalFileURLProtocol.swift */,
-				CA3EC8FDEE4DC2807E9E72F6 /* UIView+snapshot.swift */,
-				9AC7315440692AACA1241582 /* ViewTestCase.swift */,
-				B9E1399C697BC5EEF942A3CF /* ViewControllerTestCase.swift */,
-			);
-			name = UITests;
-			path = UITests;
-			sourceTree = "<group>";
-		};
-		8D60BF094FDC6EF8DB471575 /* UI */ = {
-			isa = PBXGroup;
-			children = (
-				DADE2610835FB17870F2529B /* ListScreen */,
-				22187D0F5197DABDFDD21723 /* AddItemScreen */,
-			);
-			name = UI;
-			path = UI;
-			sourceTree = "<group>";
-		};
-		94F1688C69043B613C7BE9DE /* iOS */ = {
-			isa = PBXGroup;
-			children = (
-				1D173251D097C01031976550 /* Foundation.framework */,
-				5C130AE32D4EDAC409B19A41 /* UIKit.framework */,
-			);
-			name = iOS;
-			sourceTree = "<group>";
-		};
-		A11A7BCA2DC4D9DBFFF1306B /* Subviews */ = {
-			isa = PBXGroup;
-			children = (
-				A53E2964506D66472337355C /* TextView.swift */,
-			);
-			name = Subviews;
-			path = Subviews;
-			sourceTree = "<group>";
-		};
-		A5C997FDBDFD8F9088B3D165 /* Application */ = {
-			isa = PBXGroup;
-			children = (
-				995545296A8A7AE7E8D58645 /* AppDelegate.swift */,
-			);
-			name = Application;
-			path = Application;
-			sourceTree = "<group>";
-		};
-		AEFA00A76C63B755867294DC /* DemoTests */ = {
-			isa = PBXGroup;
-			children = (
-				8DC50F0E5AA0F6C70373EBBC /* DemoTests.swift */,
-			);
-			name = DemoTests;
-			path = DemoTests;
-			sourceTree = "<group>";
-		};
-		CDACA981441DBC60BA6B6065 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				CBD200BDEA2EBF67BD1164F3 /* TempuraTests.xctest */,
-				22F42FAD59238FD79B9C8F38 /* Tempura.framework */,
-				C943382F9E5F42B501C4B974 /* TempuraTesting.framework */,
-				03207435C27B3BA015183220 /* DemoTests.xctest */,
-				1DDA36E967230883EF4E8D53 /* Demo.app */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		CE50A14BB02040C75E6353F3 /* CollectionView */ = {
-			isa = PBXGroup;
-			children = (
-				164B34F6CD3CF5FEEB1FD5B3 /* Source.swift */,
-				5A237D4BC151C98EDE2190FD /* CollectionView.swift */,
-				9D703ADC8E96A5B1810899F7 /* DataSource.swift */,
-				4A0326F9B3D7FAEED676E6B8 /* ConfigurableCell.swift */,
-			);
-			name = CollectionView;
-			path = CollectionView;
-			sourceTree = "<group>";
-		};
-		D51A7391986EEB39473CBBDB /* State */ = {
-			isa = PBXGroup;
-			children = (
-				E202D263AC91E57EF107CE6F /* AppState.swift */,
-				E7392B93FA131402229318FA /* Models.swift */,
-			);
-			name = State;
-			path = State;
-			sourceTree = "<group>";
-		};
-		D7D53C5D07F3B9EF01E37223 /* Actions */ = {
-			isa = PBXGroup;
-			children = (
-				BCA59D1B518AE32DC1182872 /* ItemActions.swift */,
-			);
-			name = Actions;
-			path = Actions;
-			sourceTree = "<group>";
-		};
-		DADE2610835FB17870F2529B /* ListScreen */ = {
-			isa = PBXGroup;
-			children = (
-				907CF40A610C54C52D1E08FA /* ListViewController.swift */,
-				73A14F07C2987E4988F7B67B /* ListView.swift */,
-				435A4657730A540501BB0086 /* Subviews */,
-				DE3D0BE0D35273882E284B4A /* ChildViewController.swift */,
+				0475499F28C825E4BB653F67 /* ListViewController.swift */,
+				0B717A43A2F026FCBC1BDCC0 /* ListView.swift */,
+				19802DF62C242B540F6D08B0 /* Subviews */,
+				40068B61E8736ECDCF8AC956 /* ChildViewController.swift */,
 			);
 			name = ListScreen;
 			path = ListScreen;
 			sourceTree = "<group>";
 		};
-		DD2A773F944A89F1F1496F66 /* Navigation */ = {
+		19802DF62C242B540F6D08B0 /* Subviews */ = {
 			isa = PBXGroup;
 			children = (
-				93A2E715A24EA2BD61386830 /* UINavigationController+Completion.swift */,
-				94990D7E78EEC74CFB590E9F /* NavigationActions.swift */,
-				5564081DF13E2DCA4A754F66 /* NavigationUtilities.swift */,
-				36226BAB6DE2963229C3C853 /* Routable.swift */,
-				077C700F068523626965D032 /* RootInstaller.swift */,
-				4267731146963574851DAFC7 /* NavigationDSL.swift */,
-				611BBDB76D0812419D552DD7 /* NavigationProvider.swift */,
-				66ED1355D2D21398BF7337F8 /* Navigator.swift */,
+				D525DF8AF883113A2D0239A5 /* ArchiveFlowLayout.swift */,
+				2249E6C7E0ACC377D139C66C /* TodoCell.swift */,
+				832B7292834EF377971CFD18 /* TodoFlowLayout.swift */,
 			);
-			name = Navigation;
-			path = Navigation;
+			name = Subviews;
+			path = Subviews;
 			sourceTree = "<group>";
 		};
-		E27B94DF3BF41203FDDBDA8C /* SupportingFiles */ = {
+		32FFFE11E63CCAFF8EF3226B /* TempuraTests */ = {
 			isa = PBXGroup;
 			children = (
-				1972A28C80AD0240B932B09D /* Tempura.h */,
+				34EEF890908267AFCE0F47A4 /* ViewControllerSpec.swift */,
+				D896F8845D203FA13DA578FA /* ViewControllerContainmentSpec.swift */,
+				0F8FF0677F29BFC2D025974C /* ViewControllerWithLocalStateSpec.swift */,
 			);
-			name = SupportingFiles;
-			path = SupportingFiles;
+			name = TempuraTests;
+			path = TempuraTests;
 			sourceTree = "<group>";
 		};
-		E4B051AA8A6A186473F9C193 /* Resources */ = {
+		33757B7A6B940952D596FFC5 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				C35DA519D7C3EAA058B502D2 /* Media.xcassets */,
+				DC5EFAA3CD31DD7C0B6FEA2C /* iOS */,
+				9053D290F6DA57F187C9CAB5 /* Pods_DemoTests.framework */,
+				686303F12664D029DE500692 /* Pods_Tempura.framework */,
+				2AAFBDD6CB61018695C145DD /* Pods_Tempura_Demo.framework */,
+				00D800CCEF057834DC16C77D /* Pods_TempuraTesting.framework */,
+				71785E672555D334C90B6D21 /* Pods_TempuraTests.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		35D0B1D10DE42F7C00A85ACE /* UITests */ = {
+			isa = PBXGroup;
+			children = (
+				BC0610F7EABA546804D12CC6 /* UITests.swift */,
+				DB4FFEE2D12C92CE1307E6FB /* LocalFileURLProtocol.swift */,
+				3A4872B7196FD0A4F9872DF5 /* UIView+snapshot.swift */,
+				E12738D9235E9889730AD937 /* ViewTestCase.swift */,
+				C0ED2D46724416E9CF59E5A0 /* ViewControllerTestCase.swift */,
+			);
+			name = UITests;
+			path = UITests;
+			sourceTree = "<group>";
+		};
+		423F8DC65F8F0364F757C8F6 /* Subviews */ = {
+			isa = PBXGroup;
+			children = (
+				C63EC6033DFD1EEE440CF3D1 /* TextView.swift */,
+			);
+			name = Subviews;
+			path = Subviews;
+			sourceTree = "<group>";
+		};
+		5B86F61F4F9C174D861EEB5F /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				8C08F1501913CAE489CD32FA /* Media.xcassets */,
 			);
 			name = Resources;
 			path = Resources;
 			sourceTree = "<group>";
 		};
-		F93EA14FC3FA4C61D2D7380E /* Navigation */ = {
+		5EEBD5A4FF44D13BDFEE1752 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
-				0F1ECA92178B8C12065DCC51 /* AppNavigation.swift */,
+				DBBC705291F6071B88EFCDF6 /* MainThread.swift */,
+			);
+			name = Utilities;
+			path = Utilities;
+			sourceTree = "<group>";
+		};
+		61B7211393A06C52ABA4C0B2 /* Application */ = {
+			isa = PBXGroup;
+			children = (
+				E07FF0D078953E0BD860BC0F /* AppDelegate.swift */,
+			);
+			name = Application;
+			path = Application;
+			sourceTree = "<group>";
+		};
+		6EB95B8BFD660EC4F86BFE09 /* SupportingFiles */ = {
+			isa = PBXGroup;
+			children = (
+				8E84EAA3084551A186FC9FCE /* Tempura.h */,
+			);
+			name = SupportingFiles;
+			path = SupportingFiles;
+			sourceTree = "<group>";
+		};
+		7CAA09C10BFDEC922E5B3E08 /* Dependencies */ = {
+			isa = PBXGroup;
+			children = (
+				A0C302DCA2D0F8ABCDDA2A4A /* DependenciesContainer.swift */,
+			);
+			name = Dependencies;
+			path = Dependencies;
+			sourceTree = "<group>";
+		};
+		8B149630959BDCE2AE97488A /* Navigation */ = {
+			isa = PBXGroup;
+			children = (
+				BFF310AE79E3273C303E9F25 /* UINavigationController+Completion.swift */,
+				97B5D69383513EC07023164F /* NavigationActions.swift */,
+				ED20C414686B10B287686EF7 /* NavigationUtilities.swift */,
+				274CA67DE7324B47E816549F /* Routable.swift */,
+				66D0F14191DA8AF97FED512B /* RootInstaller.swift */,
+				34056B8D2F55320373CBA7B2 /* NavigationDSL.swift */,
+				6E0AFC243F4CF887049FC725 /* NavigationProvider.swift */,
+				A6553F3749245E6A77B1A2CE /* Navigator.swift */,
 			);
 			name = Navigation;
 			path = Navigation;
 			sourceTree = "<group>";
 		};
+		8D34FDA05B0B22F8627E7F5E /* AddItemScreen */ = {
+			isa = PBXGroup;
+			children = (
+				423F8DC65F8F0364F757C8F6 /* Subviews */,
+				99C2A6826D6D5702CE9425AF /* AddItemView.swift */,
+				11C48B39DA231240985F7B20 /* AddItemViewController.swift */,
+			);
+			name = AddItemScreen;
+			path = AddItemScreen;
+			sourceTree = "<group>";
+		};
+		A7BF1D5714553D34146D5562 /* State */ = {
+			isa = PBXGroup;
+			children = (
+				0F23238972CB06D60209082C /* AppState.swift */,
+				4E07BCD0045E2CA10541C7BD /* Models.swift */,
+			);
+			name = State;
+			path = State;
+			sourceTree = "<group>";
+		};
+		B079D08E66B48973F8401DA7 /* UI */ = {
+			isa = PBXGroup;
+			children = (
+				113B415BBA6E6210F21036F6 /* ListScreen */,
+				8D34FDA05B0B22F8627E7F5E /* AddItemScreen */,
+			);
+			name = UI;
+			path = UI;
+			sourceTree = "<group>";
+		};
+		B7B96742917C02A908C2C83D /* Actions */ = {
+			isa = PBXGroup;
+			children = (
+				69C6CB90C6EE139CCF5B838D /* ItemActions.swift */,
+			);
+			name = Actions;
+			path = Actions;
+			sourceTree = "<group>";
+		};
+		B966DC4DD22D3E7CC18B8E1F = {
+			isa = PBXGroup;
+			children = (
+				EC95ACE9A13156424E138389 /* Products */,
+				33757B7A6B940952D596FFC5 /* Frameworks */,
+				32FFFE11E63CCAFF8EF3226B /* TempuraTests */,
+				C904067276EE74D5AE36D7E2 /* Tempura */,
+				C0F48D412432C437EDBC6CBD /* DemoTests */,
+				CDAAF3E97E0F4480F392A978 /* Demo */,
+				CB9D837BA3DB0A557E108140 /* Pods */,
+			);
+			sourceTree = "<group>";
+		};
+		C0F48D412432C437EDBC6CBD /* DemoTests */ = {
+			isa = PBXGroup;
+			children = (
+				C05310487807F0E76D63BE7A /* DemoTests.swift */,
+			);
+			name = DemoTests;
+			path = DemoTests;
+			sourceTree = "<group>";
+		};
+		C72B46073E1AADE863BEC27B /* CollectionView */ = {
+			isa = PBXGroup;
+			children = (
+				4676EB727954C1F7671D6631 /* Source.swift */,
+				564480F7905ABA6C7ABEB78A /* CollectionView.swift */,
+				08884FD53F3851A6A11D4534 /* DataSource.swift */,
+				CEA32A7BB7A56ABE9219DEA3 /* ConfigurableCell.swift */,
+			);
+			name = CollectionView;
+			path = CollectionView;
+			sourceTree = "<group>";
+		};
+		C904067276EE74D5AE36D7E2 /* Tempura */ = {
+			isa = PBXGroup;
+			children = (
+				C9664E1F59DD597BC640376C /* Core */,
+				8B149630959BDCE2AE97488A /* Navigation */,
+				5EEBD5A4FF44D13BDFEE1752 /* Utilities */,
+				35D0B1D10DE42F7C00A85ACE /* UITests */,
+				6EB95B8BFD660EC4F86BFE09 /* SupportingFiles */,
+			);
+			name = Tempura;
+			path = Tempura;
+			sourceTree = "<group>";
+		};
+		C9664E1F59DD597BC640376C /* Core */ = {
+			isa = PBXGroup;
+			children = (
+				ADCFE5F1C52A825FAF6A2C06 /* ViewController.swift */,
+				4DE04F938EABC169EA425F72 /* View.swift */,
+				8A1C3FE83DD5E3D3B6540B08 /* ViewModelWithState.swift */,
+				7D3F52EF48B81392710100B8 /* ModellableView.swift */,
+				052ED76A4B1BE6A346D1F889 /* ViewModelWithLocalState.swift */,
+				BF31774251002C3C019BDCC0 /* LocalState.swift */,
+				9487708B9F3798AA35DDAE68 /* ViewModel.swift */,
+				53A54145F093C68E64B56F7F /* ViewControllerModellableView.swift */,
+				2016522A4E514816A0AFF7CF /* ViewControllerWithLocalState.swift */,
+				CA1C2C60CA2509612B2132F2 /* ViewController+Containment.swift */,
+			);
+			name = Core;
+			path = Core;
+			sourceTree = "<group>";
+		};
+		CB9D837BA3DB0A557E108140 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				5DF746EB692CE56F05B62DDE /* Pods-DemoTests.debug.xcconfig */,
+				B92584C52ECB6EA3F82EABFE /* Pods-DemoTests.release.xcconfig */,
+				568D2512A23AABAAC553ED39 /* Pods-Tempura.debug.xcconfig */,
+				2DF35A7BE1C7E9405DDED824 /* Pods-Tempura.release.xcconfig */,
+				1F63CDF7589268E03735FC86 /* Pods-Tempura-Demo.debug.xcconfig */,
+				5F8E31565B611C17FF9FC202 /* Pods-Tempura-Demo.release.xcconfig */,
+				51227F140EC83F6211D94270 /* Pods-TempuraTesting.debug.xcconfig */,
+				997D0064D0818DC876B9BE91 /* Pods-TempuraTesting.release.xcconfig */,
+				C9DE409834C1C87B37A02470 /* Pods-TempuraTests.debug.xcconfig */,
+				FDB93D95E96253641C5A462A /* Pods-TempuraTests.release.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
+			sourceTree = "<group>";
+		};
+		CDAAF3E97E0F4480F392A978 /* Demo */ = {
+			isa = PBXGroup;
+			children = (
+				B079D08E66B48973F8401DA7 /* UI */,
+				DB64F346D3899264F9A7E6B0 /* Navigation */,
+				7CAA09C10BFDEC922E5B3E08 /* Dependencies */,
+				A7BF1D5714553D34146D5562 /* State */,
+				FE4BCAE1DC00518468E35180 /* Utilities */,
+				B7B96742917C02A908C2C83D /* Actions */,
+				61B7211393A06C52ABA4C0B2 /* Application */,
+				5B86F61F4F9C174D861EEB5F /* Resources */,
+			);
+			name = Demo;
+			path = Demo;
+			sourceTree = "<group>";
+		};
+		DB64F346D3899264F9A7E6B0 /* Navigation */ = {
+			isa = PBXGroup;
+			children = (
+				42F8C684A37536E6B3B74F09 /* AppNavigation.swift */,
+			);
+			name = Navigation;
+			path = Navigation;
+			sourceTree = "<group>";
+		};
+		DC5EFAA3CD31DD7C0B6FEA2C /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				3E9CF6D2E519EF3F9083A220 /* Foundation.framework */,
+				6467A7DF94AB92D235F11000 /* UIKit.framework */,
+			);
+			name = iOS;
+			sourceTree = "<group>";
+		};
+		EC95ACE9A13156424E138389 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				50E2E726E7A8892EDC0D6F46 /* TempuraTests.xctest */,
+				C6C5504CF990001D4F2C488E /* Tempura.framework */,
+				85212B452152F8CEAF4E1DD7 /* TempuraTesting.framework */,
+				F2BC763CC1F86172C36B3C5C /* DemoTests.xctest */,
+				A172BDAFF26CE46F24288F53 /* Demo.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		FE4BCAE1DC00518468E35180 /* Utilities */ = {
+			isa = PBXGroup;
+			children = (
+				BA0300BD1DAED4A61415B1C6 /* UIControl+TargetActionable.swift */,
+				1F17A89EC1093CC17BCF2437 /* String+Random.swift */,
+				C72B46073E1AADE863BEC27B /* CollectionView */,
+				38605F422FAC189BF77ABA15 /* CGRect+Utils.swift */,
+				CC2D9839C2FEC766B0F68351 /* UIView+Blink.swift */,
+				8AFBEDB06D415C1374C0158C /* String+Height.swift */,
+			);
+			name = Utilities;
+			path = Utilities;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
-		5C034A754F13AB802ADE4CDF /* Headers */ = {
+		6689DBCA32CB2353CE362B75 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BB0F6E1EF56164AD23E9CFA5 /* Tempura.h in Headers */,
+				BCA87C405BCF91B0ED782D0F /* Tempura.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		96C4284C20CFB8A42FE9CA68 /* Headers */ = {
+		7C8833E264E3F88F0D012E03 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6902A60816CC51C5C8C4A814 /* Tempura.h in Headers */,
+				A8C5C609AC89393A1848D50C /* Tempura.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		36639CBF94BFDF986FB81769 /* DemoTests */ = {
+		2DBFEB5C4518FCDC7132F05C /* Demo */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 6FEF51128F0F581CF38B12FA /* Build configuration list for PBXNativeTarget "DemoTests" */;
+			buildConfigurationList = 28EE0E4A94D62CA88C7DF7E5 /* Build configuration list for PBXNativeTarget "Demo" */;
 			buildPhases = (
-				05173800868A8E80716BE4D8 /* [CP] Check Pods Manifest.lock */,
-				35518798597B8C933686910D /* Frameworks */,
-				73CA390EFF592ECEC2731A4F /* Sources */,
-				CEA28BC3E5F373BF217D2893 /* Lint */,
-				49EB01901957DE7004485036 /* [CP] Embed Pods Frameworks */,
+				56AA27AAEADBB20C7F3C36DF /* [CP] Check Pods Manifest.lock */,
+				43D49F23D08A1F9CF014F360 /* Frameworks */,
+				69CB992DFFE6F7474B849E68 /* Sources */,
+				06BBB6AF0215757B0B1A180D /* Resources */,
+				565748D18A835EF46E8FD2F1 /* Lint */,
+				441902CBB6D70C3640BF46E7 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				6F20793620D19F2DFC563A8A /* PBXTargetDependency */,
-				63A39CB88DF2A2E058E7FA46 /* PBXTargetDependency */,
+				01A734528B1AA526EA605660 /* PBXTargetDependency */,
 			);
-			name = DemoTests;
-			productName = DemoTests;
-			productReference = 03207435C27B3BA015183220 /* DemoTests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
+			name = Demo;
+			productName = Demo;
+			productReference = A172BDAFF26CE46F24288F53 /* Demo.app */;
+			productType = "com.apple.product-type.application";
 		};
-		47E90BD5AE2CEA07544F18A4 /* TempuraTests */ = {
+		8B7292CC2417BBB996CFC789 /* Tempura */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = D77E89D64C27AF72B337D4BE /* Build configuration list for PBXNativeTarget "TempuraTests" */;
+			buildConfigurationList = 391FE0A63F96C236798BB957 /* Build configuration list for PBXNativeTarget "Tempura" */;
 			buildPhases = (
-				17FE9A6807E345F4A148DC73 /* [CP] Check Pods Manifest.lock */,
-				3565D5C367159A3C3BD55263 /* Frameworks */,
-				909B0B89313C18AADD85A0A4 /* Sources */,
-				0B2757FCAB005948B73A18BA /* Lint */,
-				EC675E027DB6065E28D63185 /* [CP] Embed Pods Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				91AFCB2325525F93D09B4C5A /* PBXTargetDependency */,
-			);
-			name = TempuraTests;
-			productName = TempuraTests;
-			productReference = CBD200BDEA2EBF67BD1164F3 /* TempuraTests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
-		9A7B2C2C4784A31CB213B287 /* Tempura */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 16655949552D1BE42ED4E24A /* Build configuration list for PBXNativeTarget "Tempura" */;
-			buildPhases = (
-				31479FFA9B580EEAF28384A1 /* [CP] Check Pods Manifest.lock */,
-				ECD81D2555899EAB13A3A2BE /* Frameworks */,
-				4DAE426523CB747935E10998 /* Sources */,
-				5C034A754F13AB802ADE4CDF /* Headers */,
-				FA3AE4050FD095E286297945 /* Lint */,
+				E549A07841F7BEEA33E46C65 /* [CP] Check Pods Manifest.lock */,
+				FB4573F305502A1B65310FA5 /* Frameworks */,
+				82F8B94741544ECF0B88D38E /* Sources */,
+				6689DBCA32CB2353CE362B75 /* Headers */,
+				69F921312DEA24A2B82A15C6 /* Lint */,
 			);
 			buildRules = (
 			);
@@ -643,18 +623,39 @@
 			);
 			name = Tempura;
 			productName = Tempura;
-			productReference = 22F42FAD59238FD79B9C8F38 /* Tempura.framework */;
+			productReference = C6C5504CF990001D4F2C488E /* Tempura.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		C3B2B96BE82BCDAED4C2C527 /* TempuraTesting */ = {
+		ABEAE6541ACDCBEDBB6C3020 /* DemoTests */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = FC36EC5793D081B7C39C5271 /* Build configuration list for PBXNativeTarget "TempuraTesting" */;
+			buildConfigurationList = 1958D2EE275A804D5CAFEF39 /* Build configuration list for PBXNativeTarget "DemoTests" */;
 			buildPhases = (
-				967EB0C6EA578452CCD65B8D /* [CP] Check Pods Manifest.lock */,
-				8478B7BA0BA582B57D5F2951 /* Frameworks */,
-				BAC371E5444F3E2D9EECED52 /* Sources */,
-				96C4284C20CFB8A42FE9CA68 /* Headers */,
-				FDB0FF0E5F423E66D0E66BEE /* Lint */,
+				1FC1ED4E2A5B238D1C83F1F0 /* [CP] Check Pods Manifest.lock */,
+				052E30597693BF6A5445C25F /* Frameworks */,
+				4D5C55A52BA00B71F1362873 /* Sources */,
+				E358F0F02E0BA3E524E24A2B /* Lint */,
+				F78D7D47743056E4A73C12E9 /* [CP] Embed Pods Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				DBA5B6B534B78ADB766E57E2 /* PBXTargetDependency */,
+				C1246230E8EC8189BA771DF3 /* PBXTargetDependency */,
+			);
+			name = DemoTests;
+			productName = DemoTests;
+			productReference = F2BC763CC1F86172C36B3C5C /* DemoTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		E83AC9A1F08F0A742FE602FF /* TempuraTesting */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 39EAB92A014E9D0D4DAACFBB /* Build configuration list for PBXNativeTarget "TempuraTesting" */;
+			buildPhases = (
+				F7CE1CDEB7A94DE4850E3B22 /* [CP] Check Pods Manifest.lock */,
+				CF6046519C6763C9BC9C5C08 /* Frameworks */,
+				ECD5D7859F8B3562424130F4 /* Sources */,
+				7C8833E264E3F88F0D012E03 /* Headers */,
+				AB1781F249B022D9AD1AC1C6 /* Lint */,
 			);
 			buildRules = (
 			);
@@ -662,40 +663,39 @@
 			);
 			name = TempuraTesting;
 			productName = TempuraTesting;
-			productReference = C943382F9E5F42B501C4B974 /* TempuraTesting.framework */;
+			productReference = 85212B452152F8CEAF4E1DD7 /* TempuraTesting.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		F133CD648D5FA1083759D479 /* Demo */ = {
+		FD68948F1596E6F67312F485 /* TempuraTests */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 94CB091E5375712A74F1D39E /* Build configuration list for PBXNativeTarget "Demo" */;
+			buildConfigurationList = A33C2AE33E1124A01DFB0A17 /* Build configuration list for PBXNativeTarget "TempuraTests" */;
 			buildPhases = (
-				4F802F3A2016C4CCFB471DD1 /* [CP] Check Pods Manifest.lock */,
-				762686097E1040E223C59852 /* Frameworks */,
-				A0296152AB72555AAC709E11 /* Sources */,
-				4F0F4F60F2C8E24E4D2BDEA8 /* Resources */,
-				F2F737519AC1E7284179F40E /* Lint */,
-				F384E2F226EE23EB5305752E /* [CP] Embed Pods Frameworks */,
+				D85BD63045E6CF835ADF416D /* [CP] Check Pods Manifest.lock */,
+				40C46026C0129953FA335A83 /* Frameworks */,
+				67C4CCF32B3C745F818DD0BF /* Sources */,
+				2A86E94A9AB625CD35F5125B /* Lint */,
+				C68863798EE229F0E7C7376C /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				BB43CB9E668D6FA674758EFC /* PBXTargetDependency */,
+				D1F420885BD876F0099C5258 /* PBXTargetDependency */,
 			);
-			name = Demo;
-			productName = Demo;
-			productReference = 1DDA36E967230883EF4E8D53 /* Demo.app */;
-			productType = "com.apple.product-type.application";
+			name = TempuraTests;
+			productName = TempuraTests;
+			productReference = 50E2E726E7A8892EDC0D6F46 /* TempuraTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
 		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
-		8EC533182C3CFE067090F556 /* Project object */ = {
+		492FE962CD1288564FD0DA53 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1100;
 				LastUpgradeCheck = 1100;
 			};
-			buildConfigurationList = 7792EEA86B6ABF296513F6DA /* Build configuration list for PBXProject "Tempura" */;
+			buildConfigurationList = 2C8CE42AC5345349D09BDA0A /* Build configuration list for PBXProject "Tempura" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
@@ -703,33 +703,33 @@
 				en,
 				Base,
 			);
-			mainGroup = 584F31C62524439AF2DEBAE9;
-			productRefGroup = CDACA981441DBC60BA6B6065 /* Products */;
+			mainGroup = B966DC4DD22D3E7CC18B8E1F;
+			productRefGroup = EC95ACE9A13156424E138389 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				47E90BD5AE2CEA07544F18A4 /* TempuraTests */,
-				9A7B2C2C4784A31CB213B287 /* Tempura */,
-				C3B2B96BE82BCDAED4C2C527 /* TempuraTesting */,
-				36639CBF94BFDF986FB81769 /* DemoTests */,
-				F133CD648D5FA1083759D479 /* Demo */,
+				FD68948F1596E6F67312F485 /* TempuraTests */,
+				8B7292CC2417BBB996CFC789 /* Tempura */,
+				E83AC9A1F08F0A742FE602FF /* TempuraTesting */,
+				ABEAE6541ACDCBEDBB6C3020 /* DemoTests */,
+				2DBFEB5C4518FCDC7132F05C /* Demo */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		4F0F4F60F2C8E24E4D2BDEA8 /* Resources */ = {
+		06BBB6AF0215757B0B1A180D /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				62640D5C3BC1265ED855FEEA /* Media.xcassets in Resources */,
+				7B419462209110EFC6FA2BD9 /* Media.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		05173800868A8E80716BE4D8 /* [CP] Check Pods Manifest.lock */ = {
+		1FC1ED4E2A5B238D1C83F1F0 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -751,7 +751,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		0B2757FCAB005948B73A18BA /* Lint */ = {
+		2A86E94A9AB625CD35F5125B /* Lint */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -769,7 +769,131 @@
 			shellPath = /bin/sh;
 			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
-		17FE9A6807E345F4A148DC73 /* [CP] Check Pods Manifest.lock */ = {
+		441902CBB6D70C3640BF46E7 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Tempura-Demo/Pods-Tempura-Demo-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/HydraAsync/Hydra.framework",
+				"${BUILT_PRODUCTS_DIR}/Katana/Katana.framework",
+				"${BUILT_PRODUCTS_DIR}/DeepDiff/DeepDiff.framework",
+				"${BUILT_PRODUCTS_DIR}/PinLayout/PinLayout.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Hydra.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Katana.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/DeepDiff.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/PinLayout.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Tempura-Demo/Pods-Tempura-Demo-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		565748D18A835EF46E8FD2F1 /* Lint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = Lint;
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+		56AA27AAEADBB20C7F3C36DF /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Tempura-Demo-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		69F921312DEA24A2B82A15C6 /* Lint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = Lint;
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+		AB1781F249B022D9AD1AC1C6 /* Lint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = Lint;
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+		C68863798EE229F0E7C7376C /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-TempuraTests/Pods-TempuraTests-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/HydraAsync/Hydra.framework",
+				"${BUILT_PRODUCTS_DIR}/Katana/Katana.framework",
+				"${BUILT_PRODUCTS_DIR}/Nimble/Nimble.framework",
+				"${BUILT_PRODUCTS_DIR}/Quick/Quick.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Hydra.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Katana.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Nimble.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Quick.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-TempuraTests/Pods-TempuraTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		D85BD63045E6CF835ADF416D /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -791,7 +915,25 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		31479FFA9B580EEAF28384A1 /* [CP] Check Pods Manifest.lock */ = {
+		E358F0F02E0BA3E524E24A2B /* Lint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = Lint;
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+		E549A07841F7BEEA33E46C65 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -813,7 +955,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		49EB01901957DE7004485036 /* [CP] Embed Pods Frameworks */ = {
+		F78D7D47743056E4A73C12E9 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -839,29 +981,7 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-DemoTests/Pods-DemoTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		4F802F3A2016C4CCFB471DD1 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-Tempura-Demo-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		967EB0C6EA578452CCD65B8D /* [CP] Check Pods Manifest.lock */ = {
+		F7CE1CDEB7A94DE4850E3B22 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -883,249 +1003,129 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		CEA28BC3E5F373BF217D2893 /* Lint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = Lint;
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
-		};
-		EC675E027DB6065E28D63185 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-TempuraTests/Pods-TempuraTests-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/HydraAsync/Hydra.framework",
-				"${BUILT_PRODUCTS_DIR}/Katana/Katana.framework",
-				"${BUILT_PRODUCTS_DIR}/Nimble/Nimble.framework",
-				"${BUILT_PRODUCTS_DIR}/Quick/Quick.framework",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Hydra.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Katana.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Nimble.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Quick.framework",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-TempuraTests/Pods-TempuraTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		F2F737519AC1E7284179F40E /* Lint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = Lint;
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
-		};
-		F384E2F226EE23EB5305752E /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Tempura-Demo/Pods-Tempura-Demo-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/HydraAsync/Hydra.framework",
-				"${BUILT_PRODUCTS_DIR}/Katana/Katana.framework",
-				"${BUILT_PRODUCTS_DIR}/DeepDiff/DeepDiff.framework",
-				"${BUILT_PRODUCTS_DIR}/PinLayout/PinLayout.framework",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Hydra.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Katana.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/DeepDiff.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/PinLayout.framework",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Tempura-Demo/Pods-Tempura-Demo-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		FA3AE4050FD095E286297945 /* Lint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = Lint;
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
-		};
-		FDB0FF0E5F423E66D0E66BEE /* Lint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = Lint;
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
-		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		4DAE426523CB747935E10998 /* Sources */ = {
+		4D5C55A52BA00B71F1362873 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6752CCE8453D2481D2D7F1B0 /* ViewController.swift in Sources */,
-				9B839B60261ABB64C993F98A /* View.swift in Sources */,
-				ACAF6CF7BB336F6F4C3C24D1 /* ViewModelWithState.swift in Sources */,
-				CDB0B03F11357A63FC30F8B0 /* ModellableView.swift in Sources */,
-				ED9DDF99494335BAFC5AE3F3 /* ViewModelWithLocalState.swift in Sources */,
-				2C91DF1DDBF43118370E7843 /* LocalState.swift in Sources */,
-				A93F6A743B0D6A2EE43FE3A5 /* ViewModel.swift in Sources */,
-				5FD41A4BFFF656718C3FFDAC /* ViewControllerModellableView.swift in Sources */,
-				FA72ED0C5378180E05494A41 /* ViewControllerWithLocalState.swift in Sources */,
-				7515EBCDA7D68B3D7D2A199A /* ViewController+Containment.swift in Sources */,
-				366DFD7D1FF452047A8466BF /* UINavigationController+Completion.swift in Sources */,
-				CE7E561A52732025016E9AE6 /* NavigationActions.swift in Sources */,
-				1F2B6F84C8C534759AC1695A /* NavigationUtilities.swift in Sources */,
-				3C64D84F52EB4E72AF4E819A /* Routable.swift in Sources */,
-				6442760EEE874C7B086CABDB /* RootInstaller.swift in Sources */,
-				15693720E48E2CB0D466100C /* NavigationDSL.swift in Sources */,
-				16F49F1816FCF15CD5FEB646 /* NavigationProvider.swift in Sources */,
-				7050586D8609EF254C8CED85 /* Navigator.swift in Sources */,
-				96F280DDF3B0F102319ABD06 /* MainThread.swift in Sources */,
+				6355D6BDBEB109E18FB4F976 /* DemoTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		73CA390EFF592ECEC2731A4F /* Sources */ = {
+		67C4CCF32B3C745F818DD0BF /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BFD48F41F7B6860E3D3AFEF1 /* DemoTests.swift in Sources */,
+				FEC598245CAC074324213E83 /* ViewControllerSpec.swift in Sources */,
+				9F449F3307231648B2A7C5E9 /* ViewControllerContainmentSpec.swift in Sources */,
+				015CABF4F89565C284547D76 /* ViewControllerWithLocalStateSpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		909B0B89313C18AADD85A0A4 /* Sources */ = {
+		69CB992DFFE6F7474B849E68 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				276D9911D025FA454429031F /* ViewControllerSpec.swift in Sources */,
-				4155E662A6311E2174E2D6B2 /* ViewControllerContainmentSpec.swift in Sources */,
-				374049D0F43461E632DA1521 /* ViewControllerWithLocalStateSpec.swift in Sources */,
+				11ED3672DD93C2308ECF975C /* ListViewController.swift in Sources */,
+				29C9308CF3FB41DA827B83DC /* ListView.swift in Sources */,
+				F60BEC64669EAD92990451F3 /* ArchiveFlowLayout.swift in Sources */,
+				4C5B1136319630E96A38E418 /* TodoCell.swift in Sources */,
+				870041DA410ED1B272B6E574 /* TodoFlowLayout.swift in Sources */,
+				E02D3CAA7368B3E147B60EAE /* ChildViewController.swift in Sources */,
+				2F180FA03D834DC3EEBE4B81 /* TextView.swift in Sources */,
+				9F0FE9B5778B025570A83EA2 /* AddItemView.swift in Sources */,
+				372C132805B9F1A7E1025630 /* AddItemViewController.swift in Sources */,
+				6F72617AC3FBFB96CA6C09A4 /* AppNavigation.swift in Sources */,
+				5EEE26D35B49A757AC448561 /* DependenciesContainer.swift in Sources */,
+				1B7873CFDE5B8E0450C35D43 /* AppState.swift in Sources */,
+				BE03606634C50410E983C063 /* Models.swift in Sources */,
+				9FCC26D967875EE7B00C589B /* UIControl+TargetActionable.swift in Sources */,
+				B013888D5925B9D3946D88E1 /* String+Random.swift in Sources */,
+				2F83B15AB791FB34005D12A0 /* Source.swift in Sources */,
+				71617DC8FEC76480BF6A838D /* CollectionView.swift in Sources */,
+				33D2785DD193C6C66362B7FF /* DataSource.swift in Sources */,
+				4F88720FCD65ED189EB72DCA /* ConfigurableCell.swift in Sources */,
+				AF7F9040F3B63D68DA4379EA /* CGRect+Utils.swift in Sources */,
+				90D61CEAE6FACF30595308A3 /* UIView+Blink.swift in Sources */,
+				2179D1576C7BF0548D1AB468 /* String+Height.swift in Sources */,
+				D758867F54D06CEFEFD1301F /* ItemActions.swift in Sources */,
+				A4EB61AB3CBDC738B871582A /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		A0296152AB72555AAC709E11 /* Sources */ = {
+		82F8B94741544ECF0B88D38E /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F1517BD59DCF843518DBC5D3 /* ListViewController.swift in Sources */,
-				D4E73377102DB96BB9833A18 /* ListView.swift in Sources */,
-				A3566DEA66C3D53271E8F003 /* ArchiveFlowLayout.swift in Sources */,
-				A520426AD6FC3E6FCD494B5F /* TodoCell.swift in Sources */,
-				173031089F26CC74607BD3BF /* TodoFlowLayout.swift in Sources */,
-				8DA3B85E6E17DE0D33844C26 /* ChildViewController.swift in Sources */,
-				A9618DC73EC28D4EDC359FD9 /* TextView.swift in Sources */,
-				ADED57C54A077E3F0072BB5E /* AddItemView.swift in Sources */,
-				6D769915D9FD627582137397 /* AddItemViewController.swift in Sources */,
-				78907D2EA385EDCBBFB66AC3 /* AppNavigation.swift in Sources */,
-				5B6CD95C28339C832D3BBE95 /* DependenciesContainer.swift in Sources */,
-				0B40F885055AF0ED9E7C1F05 /* AppState.swift in Sources */,
-				956ECE61861A11B2D5A3CE6D /* Models.swift in Sources */,
-				8B8A3C7D229764490703D96F /* UIControl+TargetActionable.swift in Sources */,
-				C337643FD022F28ED5FB9ED4 /* String+Random.swift in Sources */,
-				24CF6B734B00054961F90E32 /* Source.swift in Sources */,
-				1D8FB5CA9F23A630FE4730C5 /* CollectionView.swift in Sources */,
-				3F6D32AC5532E7AEC948A542 /* DataSource.swift in Sources */,
-				AC2114E0CD7993C96F55AA82 /* ConfigurableCell.swift in Sources */,
-				D72356D6A3B6058127B8C734 /* CGRect+Utils.swift in Sources */,
-				EB16DE1D7508E101CA6717D2 /* UIView+Blink.swift in Sources */,
-				85D0FEE49166EA8743AE82C1 /* String+Height.swift in Sources */,
-				B7270653DE261278782C65D6 /* ItemActions.swift in Sources */,
-				2D9235DD879ACBB89F363AF6 /* AppDelegate.swift in Sources */,
+				35A2F0556069969E72D78AB0 /* ViewController.swift in Sources */,
+				ED8FB2320F3565D7925ABDB9 /* View.swift in Sources */,
+				19B9EA746AA99CE348484CDF /* ViewModelWithState.swift in Sources */,
+				BA7C118127F2ED0579581A1F /* ModellableView.swift in Sources */,
+				65BAF78E5152F0CD99DA8FE5 /* ViewModelWithLocalState.swift in Sources */,
+				9DC2393D92E5B13868ED3B27 /* LocalState.swift in Sources */,
+				F972509E112CE71BDA9CE893 /* ViewModel.swift in Sources */,
+				E497E22BB8ADB674E592B1C8 /* ViewControllerModellableView.swift in Sources */,
+				43CB2439637DB8BAF4B65715 /* ViewControllerWithLocalState.swift in Sources */,
+				9307F2FE91542A5D810743DE /* ViewController+Containment.swift in Sources */,
+				5AEA8F5BF0EDB4C13EC3C528 /* UINavigationController+Completion.swift in Sources */,
+				199CE12AEABF6F6841F26697 /* NavigationActions.swift in Sources */,
+				66D15348EC5B9CA1ED760EED /* NavigationUtilities.swift in Sources */,
+				90BB353018B3EB1633EDA7BD /* Routable.swift in Sources */,
+				58883F526B6B281CBA7537F6 /* RootInstaller.swift in Sources */,
+				3532348AF809F51CC3D08035 /* NavigationDSL.swift in Sources */,
+				A5BCDDD9A22A4F50FCA19DDD /* NavigationProvider.swift in Sources */,
+				69774EAC2CF4650914D13AA1 /* Navigator.swift in Sources */,
+				3F13CAD64CBF9568686025C2 /* MainThread.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		BAC371E5444F3E2D9EECED52 /* Sources */ = {
+		ECD5D7859F8B3562424130F4 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F490CAA9033845F307B1E588 /* UITests.swift in Sources */,
-				204DA40CDE139295A1D7FAEF /* LocalFileURLProtocol.swift in Sources */,
-				003A74B417A6AEA0C6662521 /* UIView+snapshot.swift in Sources */,
-				4A19838FCCEEB877D0044609 /* ViewTestCase.swift in Sources */,
-				2EDE730F3776F9AA8930B836 /* ViewControllerTestCase.swift in Sources */,
+				7C5327B47CF6296EBEE0D0CD /* UITests.swift in Sources */,
+				D496137C8FCCCEF39E335913 /* LocalFileURLProtocol.swift in Sources */,
+				4629A18B482DCE07453FE2FD /* UIView+snapshot.swift in Sources */,
+				A1BB3C07E945D3EA077C2E11 /* ViewTestCase.swift in Sources */,
+				CF723FCB8BBED7832A772C84 /* ViewControllerTestCase.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		63A39CB88DF2A2E058E7FA46 /* PBXTargetDependency */ = {
+		01A734528B1AA526EA605660 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Tempura;
+			target = 8B7292CC2417BBB996CFC789 /* Tempura */;
+			targetProxy = B4413295C8E51889E0DCF179 /* PBXContainerItemProxy */;
+		};
+		C1246230E8EC8189BA771DF3 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = TempuraTesting;
-			target = C3B2B96BE82BCDAED4C2C527 /* TempuraTesting */;
-			targetProxy = AA4FDDB9F87D0DB5C9495E3F /* PBXContainerItemProxy */;
+			target = E83AC9A1F08F0A742FE602FF /* TempuraTesting */;
+			targetProxy = 21BB65CD083898EAF5D3ABB1 /* PBXContainerItemProxy */;
 		};
-		6F20793620D19F2DFC563A8A /* PBXTargetDependency */ = {
+		D1F420885BD876F0099C5258 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Tempura;
+			target = 8B7292CC2417BBB996CFC789 /* Tempura */;
+			targetProxy = CE0BF864545BEDEBECEC8A58 /* PBXContainerItemProxy */;
+		};
+		DBA5B6B534B78ADB766E57E2 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = Demo;
-			target = F133CD648D5FA1083759D479 /* Demo */;
-			targetProxy = 3E94D9AB36086D71D1FD3806 /* PBXContainerItemProxy */;
-		};
-		91AFCB2325525F93D09B4C5A /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Tempura;
-			target = 9A7B2C2C4784A31CB213B287 /* Tempura */;
-			targetProxy = 0079F4AE23BE7BCA0FBB1B39 /* PBXContainerItemProxy */;
-		};
-		BB43CB9E668D6FA674758EFC /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Tempura;
-			target = 9A7B2C2C4784A31CB213B287 /* Tempura */;
-			targetProxy = 9E17CB8A8DE47C8A983B66F4 /* PBXContainerItemProxy */;
+			target = 2DBFEB5C4518FCDC7132F05C /* Demo */;
+			targetProxy = 055A11CFA7E90E7C5D076BDF /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		008C44B27F245978DC43D73B /* Debug */ = {
+		333E477A4284643E8177CFCB /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 569E390CCB8B0146A15D1AEB /* Pods-TempuraTesting.debug.xcconfig */;
+			baseConfigurationReference = 997D0064D0818DC876B9BE91 /* Pods-TempuraTesting.release.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				CURRENT_PROJECT_VERSION = 1;
@@ -1144,78 +1144,15 @@
 				PRODUCT_NAME = TempuraTesting;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
-			name = Debug;
+			name = Release;
 		};
-		2CED711E53410BB5F0BD13C2 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 3E85CCD29540E3DEE2DA87F0 /* Pods-Tempura-Demo.debug.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				INFOPLIST_FILE = Demo/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = dk.bendingspoons.AppStation;
-				PRODUCT_NAME = Demo;
-				SDKROOT = iphoneos;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Debug;
-		};
-		5AECE5FB29DD4FEEA4F08532 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 1072A73394C9DE763373F81E /* Pods-Tempura.debug.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				INFOPLIST_FILE = Tempura/SupportingFiles/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_NAME = Tempura;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		7A6C85C7440240ED5F7BA843 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = C8EA6B9D00FA578ACCF03D70 /* Pods-DemoTests.debug.xcconfig */;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				INFOPLIST_FILE = DemoTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				SDKROOT = iphoneos;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Demo.app/Demo";
-			};
-			name = Debug;
-		};
-		7F367232544C854E44B1231B /* Debug */ = {
+		4241EB0A676CB7C9987535E8 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -1275,9 +1212,9 @@
 			};
 			name = Debug;
 		};
-		8F5E62497F4364B8AEA3E14B /* Release */ = {
+		56133679D41D73A1C37AA5C6 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F29DBB122D76B66BE9B82FEF /* Pods-DemoTests.release.xcconfig */;
+			baseConfigurationReference = 5DF746EB692CE56F05B62DDE /* Pods-DemoTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -1285,15 +1222,44 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Demo.app/Demo";
-				VALIDATE_PRODUCT = YES;
 			};
-			name = Release;
+			name = Debug;
 		};
-		924AA5D39C0F6C387BEC85BB /* Release */ = {
+		5BBCA1B708B3C12F53CCC640 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5AFC07783E89FF67C96D2EB4 /* Pods-Tempura-Demo.release.xcconfig */;
+			baseConfigurationReference = 568D2512A23AABAAC553ED39 /* Pods-Tempura.debug.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				INFOPLIST_FILE = Tempura/SupportingFiles/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = Tempura;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		5CAAA09DD63B1567B1659591 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 5F8E31565B611C17FF9FC202 /* Pods-Tempura-Demo.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -1309,9 +1275,38 @@
 			};
 			name = Release;
 		};
-		948A6EB6C8431407DDD2DEF2 /* Debug */ = {
+		5F41F1F844545930A035AD6B /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F70BA8019F66F30D9FFAB9F0 /* Pods-TempuraTests.debug.xcconfig */;
+			baseConfigurationReference = 51227F140EC83F6211D94270 /* Pods-TempuraTesting.debug.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				INFOPLIST_FILE = Tempura/SupportingFiles/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = TempuraTesting;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		60A6CCBB4AEC6B05A4B22DEF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = C9DE409834C1C87B37A02470 /* Pods-TempuraTests.debug.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				INFOPLIST_FILE = TempuraTests/Info.plist;
@@ -1323,7 +1318,39 @@
 			};
 			name = Debug;
 		};
-		A57AC283733D5F96554CD4B9 /* Release */ = {
+		7ED18F8E1AE1E47DB5F2CEDA /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1F63CDF7589268E03735FC86 /* Pods-Tempura-Demo.debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				INFOPLIST_FILE = Demo/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = dk.bendingspoons.AppStation;
+				PRODUCT_NAME = Demo;
+				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		92106634BE3D747F11D3D926 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FDB93D95E96253641C5A462A /* Pods-TempuraTests.release.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				INFOPLIST_FILE = TempuraTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		CCD6CBF6F744AC93FF52B8D9 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -1376,52 +1403,9 @@
 			};
 			name = Release;
 		};
-		B92DD146D03A6AE8D7668425 /* Release */ = {
+		F169DECF0EB55567E67906D4 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7F8048FD19E805306CFC1017 /* Pods-TempuraTests.release.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				INFOPLIST_FILE = TempuraTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				SDKROOT = iphoneos;
-				SWIFT_VERSION = 5.0;
-				VALIDATE_PRODUCT = YES;
-			};
-			name = Release;
-		};
-		D1390F0926C2ABD10292987B /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = F86D79A5717CA3800CF3EAC9 /* Pods-TempuraTesting.release.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				INFOPLIST_FILE = Tempura/SupportingFiles/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_NAME = TempuraTesting;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		E7517035A1221FD225A628A8 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0D79233B0CEED31350194F1C /* Pods-Tempura.release.xcconfig */;
+			baseConfigurationReference = 2DF35A7BE1C7E9405DDED824 /* Pods-Tempura.release.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				CURRENT_PROJECT_VERSION = 1;
@@ -1448,64 +1432,80 @@
 			};
 			name = Release;
 		};
+		FD6053A5FF9D9A31DEC9D848 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = B92584C52ECB6EA3F82EABFE /* Pods-DemoTests.release.xcconfig */;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				INFOPLIST_FILE = DemoTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Demo.app/Demo";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		16655949552D1BE42ED4E24A /* Build configuration list for PBXNativeTarget "Tempura" */ = {
+		1958D2EE275A804D5CAFEF39 /* Build configuration list for PBXNativeTarget "DemoTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				5AECE5FB29DD4FEEA4F08532 /* Debug */,
-				E7517035A1221FD225A628A8 /* Release */,
+				56133679D41D73A1C37AA5C6 /* Debug */,
+				FD6053A5FF9D9A31DEC9D848 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		6FEF51128F0F581CF38B12FA /* Build configuration list for PBXNativeTarget "DemoTests" */ = {
+		28EE0E4A94D62CA88C7DF7E5 /* Build configuration list for PBXNativeTarget "Demo" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				7A6C85C7440240ED5F7BA843 /* Debug */,
-				8F5E62497F4364B8AEA3E14B /* Release */,
+				7ED18F8E1AE1E47DB5F2CEDA /* Debug */,
+				5CAAA09DD63B1567B1659591 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		7792EEA86B6ABF296513F6DA /* Build configuration list for PBXProject "Tempura" */ = {
+		2C8CE42AC5345349D09BDA0A /* Build configuration list for PBXProject "Tempura" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				7F367232544C854E44B1231B /* Debug */,
-				A57AC283733D5F96554CD4B9 /* Release */,
+				4241EB0A676CB7C9987535E8 /* Debug */,
+				CCD6CBF6F744AC93FF52B8D9 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		94CB091E5375712A74F1D39E /* Build configuration list for PBXNativeTarget "Demo" */ = {
+		391FE0A63F96C236798BB957 /* Build configuration list for PBXNativeTarget "Tempura" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				2CED711E53410BB5F0BD13C2 /* Debug */,
-				924AA5D39C0F6C387BEC85BB /* Release */,
+				5BBCA1B708B3C12F53CCC640 /* Debug */,
+				F169DECF0EB55567E67906D4 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		D77E89D64C27AF72B337D4BE /* Build configuration list for PBXNativeTarget "TempuraTests" */ = {
+		39EAB92A014E9D0D4DAACFBB /* Build configuration list for PBXNativeTarget "TempuraTesting" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				948A6EB6C8431407DDD2DEF2 /* Debug */,
-				B92DD146D03A6AE8D7668425 /* Release */,
+				5F41F1F844545930A035AD6B /* Debug */,
+				333E477A4284643E8177CFCB /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		FC36EC5793D081B7C39C5271 /* Build configuration list for PBXNativeTarget "TempuraTesting" */ = {
+		A33C2AE33E1124A01DFB0A17 /* Build configuration list for PBXNativeTarget "TempuraTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				008C44B27F245978DC43D73B /* Debug */,
-				D1390F0926C2ABD10292987B /* Release */,
+				60A6CCBB4AEC6B05A4B22DEF /* Debug */,
+				92106634BE3D747F11D3D926 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};
-	rootObject = 8EC533182C3CFE067090F556 /* Project object */;
+	rootObject = 492FE962CD1288564FD0DA53 /* Project object */;
 }

--- a/Tempura.xcodeproj/project.pbxproj
+++ b/Tempura.xcodeproj/project.pbxproj
@@ -7,615 +7,635 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0311E6E7C788907865D30EAC /* Pods_TempuraTesting.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4EA052C0323E0CF37B855B51 /* Pods_TempuraTesting.framework */; };
-		05E2534CB0949F57C289B17B /* TodoCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D667185BCE5059D0229114C /* TodoCell.swift */; };
-		0F545B381C8FBACB79C6067A /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BD45992CF402F8F79775E8E /* UIKit.framework */; };
-		13925A6071FDB72B0F81753A /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 124087508DB9D22AEB329B68 /* ViewController.swift */; };
-		15B37D299F533123CA928E89 /* Navigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E833A490FB237B32F8D704 /* Navigator.swift */; };
-		164BFE537307B1DE296C1BD9 /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E74774ED639DCDB10E992BB /* Models.swift */; };
-		16D0F5B72CFC3A8DB7C1ED34 /* ArchiveFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 066BD29BE68B0F984E18B070 /* ArchiveFlowLayout.swift */; };
-		17437108D9C0094AF2D665F3 /* ViewTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86701B6C0EDB65EDEB07806B /* ViewTestCase.swift */; };
-		1A20A82D89E916C8EC185BE1 /* NavigationUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D66306B4F49BB36F3AB7686 /* NavigationUtilities.swift */; };
-		1FBF488F33EC00FCB88C9A77 /* Routable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D6D4F6DC99F26CDBEA1289D /* Routable.swift */; };
-		286E70FC894B769127E6144F /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 365C7ADAAD83E34B6DF33553 /* Foundation.framework */; };
-		29A75BED0EF5A827341EB73A /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BD45992CF402F8F79775E8E /* UIKit.framework */; };
-		2A59B2588D5039E9742C0FEE /* ListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAC29BB68511803008671B81 /* ListViewController.swift */; };
-		2B2F433F3C1381BE8895D70C /* ViewControllerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBC2ABC900303DE2866BF967 /* ViewControllerSpec.swift */; };
-		331E6014ECDC140319AE0A33 /* CollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5438311309EEE332B044EF76 /* CollectionView.swift */; };
-		381645D475DD642774EE1FB6 /* ViewModelWithLocalState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5606D63EECCE87514317710 /* ViewModelWithLocalState.swift */; };
-		3DAC790CF1EA187168CC369C /* UIView+Blink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 430BEB8CA3EBCB7533735974 /* UIView+Blink.swift */; };
-		401C27D9182B5710B17217F0 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8872EF76E2782A6E0014500 /* AppState.swift */; };
-		4173BF2B98ABDB7A4F9F52DD /* UIControl+TargetActionable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29A5058D1FD03E80F864E9BF /* UIControl+TargetActionable.swift */; };
-		4AD473966E75953A560ACFB8 /* ViewControllerContainmentSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87E4C6ABC71FC1664E4FF861 /* ViewControllerContainmentSpec.swift */; };
-		4CABCB025B0BF586FCACFEE5 /* ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CFCE2875FC533BDF567B430 /* ViewModel.swift */; };
-		516DC45C7356957DC7AF6650 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 365C7ADAAD83E34B6DF33553 /* Foundation.framework */; };
-		56DE6F862E7EE0A1D260C757 /* Pods_Tempura_Demo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3DF32F34E08702F9882D112A /* Pods_Tempura_Demo.framework */; };
-		5807334E7EE8D7882E3C2204 /* ModellableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 797C94A33B6035CB3FC26C2C /* ModellableView.swift */; };
-		583E3DADF9F8D7C140844D21 /* DependenciesContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41527ABF1B6837B8AF7F3328 /* DependenciesContainer.swift */; };
-		653EE0027CA643E4DF1441DB /* TodoFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4EFE88F3C638250463B4FA2 /* TodoFlowLayout.swift */; };
-		67FE082E1FCE8D9B2B93692D /* LocalState.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABEBC105FBB3704C0A040991 /* LocalState.swift */; };
-		698DFC2C2567B939F0FCD3A3 /* ItemActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E5D2185CF44CE41AE3F02EF /* ItemActions.swift */; };
-		6BB22A800B8303D7FD04219F /* ViewModelWithState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63049672E490DD80E4AB15EB /* ViewModelWithState.swift */; };
-		6D56B8C0BC4BD89BAB0C9C1F /* DataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB477FF662BDDB587C628AFA /* DataSource.swift */; };
-		6EA7FD807A80F89EE7FD1464 /* Pods_TempuraTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C74724C0E93FB2E2E0711EA1 /* Pods_TempuraTests.framework */; };
-		6FE6DDC49215D6D17365B887 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BD45992CF402F8F79775E8E /* UIKit.framework */; };
-		720FF52E09111A777003474D /* Tempura.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8AC45BAB0DC56AA13EBEB62 /* Tempura.framework */; };
-		754FDF4F8444F74AE5469556 /* AddItemViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CBE957E5809A4C35ED1257C /* AddItemViewController.swift */; };
-		7811FF4D9522E68441422C07 /* Source.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E0E3BFA3212CC179BC4F929 /* Source.swift */; };
-		791DDFED0CBF678D2C973B84 /* ViewController+Containment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F98A7DFA046E3A07EE3A567 /* ViewController+Containment.swift */; };
-		7B9AA70D1D1BA816A91937C8 /* ViewControllerWithLocalState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 854D7436C27D2BFB638F66FE /* ViewControllerWithLocalState.swift */; };
-		84DFEBDA0709D7840369EB21 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BD45992CF402F8F79775E8E /* UIKit.framework */; };
-		85A86393FC0E407A8928F9E3 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 365C7ADAAD83E34B6DF33553 /* Foundation.framework */; };
-		85C2305339E3864DEB0BDF5E /* DemoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2F4D5205058D032237FF3E0 /* DemoTests.swift */; };
-		8A669B6A2402C681AD7B22F8 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 365C7ADAAD83E34B6DF33553 /* Foundation.framework */; };
-		8AEB85629A437B4D01DD21D6 /* UIView+snapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC727A979E70A5B2A5D11384 /* UIView+snapshot.swift */; };
-		8B9378BDE132B44BCCCA9B45 /* UITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A73CEBBED3723AB91E50AD43 /* UITests.swift */; };
-		8BF4A2ACC316A3AEF31E0550 /* Pods_DemoTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3B0746BC10A813F6C8778E79 /* Pods_DemoTests.framework */; };
-		9666B94F1723376D83513E19 /* Pods_Tempura.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5DAE92FF322ADFE9FD055FB9 /* Pods_Tempura.framework */; };
-		96C90C5CB738DBEBACD186FF /* MainThread.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B4FB4401B27E99C0304F6FC /* MainThread.swift */; };
-		97DB015BCAA5F55641DED7ED /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BD45992CF402F8F79775E8E /* UIKit.framework */; };
-		A30654AB82587AC95D2106E3 /* ChildViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 691B5AAF78D0ABFF0B97FC1D /* ChildViewController.swift */; };
-		A3246A89828660487607D4AE /* ViewControllerModellableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD9C11902C24A2C9AAE0157 /* ViewControllerModellableView.swift */; };
-		A6A30913DB413CB27F51DA60 /* NavigationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = C55863BDC39902606A38256C /* NavigationProvider.swift */; };
-		A6FEDEECDBA174CAAA5DAEF5 /* Demo.app in Frameworks */ = {isa = PBXBuildFile; fileRef = 3CE9616DD53A600BD4B573C5 /* Demo.app */; };
-		A916AB90CCCBDBFAEB2044FD /* Media.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CD88C54DB088501AE41771FC /* Media.xcassets */; };
-		AA2679831D713F6459355C5F /* View.swift in Sources */ = {isa = PBXBuildFile; fileRef = D18A416893AB0479B28B8986 /* View.swift */; };
-		ACF0E5024453640C0EEEA719 /* NavigationActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27ECB61436DEF80BE9F328ED /* NavigationActions.swift */; };
-		B0F7C0A25316670291BDFA38 /* Tempura.h in Headers */ = {isa = PBXBuildFile; fileRef = BDC31BA2BF86D2680A23E319 /* Tempura.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B9A9C7EE65200C11A3545A43 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9DA70412AAC2D7B68E1D8E8 /* AppDelegate.swift */; };
-		BA447B21D436A5916D32E922 /* TextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EABFD66BC29C2F8C9454A4FA /* TextView.swift */; };
-		BC768E11101864BE218D150F /* Tempura.h in Headers */ = {isa = PBXBuildFile; fileRef = BDC31BA2BF86D2680A23E319 /* Tempura.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BD903C3385484D5964202F9C /* String+Random.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E691D05957D60233CE5B495 /* String+Random.swift */; };
-		C32A373AE5DD74F4E7A906F2 /* ListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC2AB3843ABFFEF783B2FA36 /* ListView.swift */; };
-		CA06A90213FE789A07C5AEA6 /* String+Height.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34FCBBA8101EF25F84AABBAD /* String+Height.swift */; };
-		CD30A34C9F58414F7B71CB10 /* UINavigationController+Completion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05DD995750DA2BD9101273AD /* UINavigationController+Completion.swift */; };
-		D1BCEA441DB3FCDA12159BD0 /* ViewControllerTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DE0220F6B220A8E272E2D8F /* ViewControllerTestCase.swift */; };
-		D6D9BD3DA0FD0307B6F62D13 /* TempuraTesting.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 34E120467BD6EC7E76E20896 /* TempuraTesting.framework */; };
-		DA7699F1C284567A72EA6DF3 /* CGRect+Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAC722305AF44A222379BEE0 /* CGRect+Utils.swift */; };
-		DC787376F7CC41C5A8239DC6 /* AppNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3926C5BF6087C1B041B958B /* AppNavigation.swift */; };
-		DC97415E496CCF4540BE62B5 /* AddItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE0738530729F8CEFFFB883A /* AddItemView.swift */; };
-		EDA9631F88684BFE6F175D9E /* ConfigurableCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2FEAC4E5310B1CBD272137E /* ConfigurableCell.swift */; };
-		F3362759DC492B650AF41E97 /* ViewControllerWithLocalStateSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05D656105211F5F476174322 /* ViewControllerWithLocalStateSpec.swift */; };
-		F35BBF87B66743752612C678 /* LocalFileURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = F59068F107DD5A8AE4AF7FC3 /* LocalFileURLProtocol.swift */; };
-		F3B3E7802187CC374D623BD2 /* Tempura.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8AC45BAB0DC56AA13EBEB62 /* Tempura.framework */; };
-		FD70636F9BBF8DD4EDF75849 /* RootInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C91621A472FB358A9175000 /* RootInstaller.swift */; };
-		FE96643D9C93BB72A767AD3F /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 365C7ADAAD83E34B6DF33553 /* Foundation.framework */; };
-		FEB890D178B837BA2DE4AD10 /* NavigationDSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95F5BF15B3ADE7E7D80F6133 /* NavigationDSL.swift */; };
+		003A74B417A6AEA0C6662521 /* UIView+snapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA3EC8FDEE4DC2807E9E72F6 /* UIView+snapshot.swift */; };
+		0B40F885055AF0ED9E7C1F05 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = E202D263AC91E57EF107CE6F /* AppState.swift */; };
+		15693720E48E2CB0D466100C /* NavigationDSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4267731146963574851DAFC7 /* NavigationDSL.swift */; };
+		16F49F1816FCF15CD5FEB646 /* NavigationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 611BBDB76D0812419D552DD7 /* NavigationProvider.swift */; };
+		173031089F26CC74607BD3BF /* TodoFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DCF78D34AC9F62FB9A391C4 /* TodoFlowLayout.swift */; };
+		1D8FB5CA9F23A630FE4730C5 /* CollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A237D4BC151C98EDE2190FD /* CollectionView.swift */; };
+		1E87CEDD2938DAA2CA3945A6 /* Pods_TempuraTesting.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 819DAD0969CDCE437CAE1FCD /* Pods_TempuraTesting.framework */; };
+		1F2B6F84C8C534759AC1695A /* NavigationUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5564081DF13E2DCA4A754F66 /* NavigationUtilities.swift */; };
+		1F34C5E853BCC8427875CAE6 /* Pods_Tempura_Demo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B57588FD20A78D0F349A51D0 /* Pods_Tempura_Demo.framework */; };
+		204DA40CDE139295A1D7FAEF /* LocalFileURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = E46224FFEBC481FA50279FEE /* LocalFileURLProtocol.swift */; };
+		24CF6B734B00054961F90E32 /* Source.swift in Sources */ = {isa = PBXBuildFile; fileRef = 164B34F6CD3CF5FEEB1FD5B3 /* Source.swift */; };
+		276D9911D025FA454429031F /* ViewControllerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A5C33BAFA60225650D6B732 /* ViewControllerSpec.swift */; };
+		2C03CB7A775BB3E56B70CDE8 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C130AE32D4EDAC409B19A41 /* UIKit.framework */; };
+		2C91DF1DDBF43118370E7843 /* LocalState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44FDD6974A9AAE917A1B84A3 /* LocalState.swift */; };
+		2D9235DD879ACBB89F363AF6 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995545296A8A7AE7E8D58645 /* AppDelegate.swift */; };
+		2EDE730F3776F9AA8930B836 /* ViewControllerTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9E1399C697BC5EEF942A3CF /* ViewControllerTestCase.swift */; };
+		3374D1553431F02B994DEED7 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D173251D097C01031976550 /* Foundation.framework */; };
+		366DFD7D1FF452047A8466BF /* UINavigationController+Completion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93A2E715A24EA2BD61386830 /* UINavigationController+Completion.swift */; };
+		374049D0F43461E632DA1521 /* ViewControllerWithLocalStateSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 184B014CD1FFE92F896DFC30 /* ViewControllerWithLocalStateSpec.swift */; };
+		3C64D84F52EB4E72AF4E819A /* Routable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36226BAB6DE2963229C3C853 /* Routable.swift */; };
+		3F6D32AC5532E7AEC948A542 /* DataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D703ADC8E96A5B1810899F7 /* DataSource.swift */; };
+		4097B99BD8B9A0C8E766B5AF /* Pods_Tempura.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1FD1C4CAC97F75A7333C7D72 /* Pods_Tempura.framework */; };
+		4155E662A6311E2174E2D6B2 /* ViewControllerContainmentSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6D5BC69D3350D1B9D715C3C /* ViewControllerContainmentSpec.swift */; };
+		43C7C5BE9F0ECA33A60D5357 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C130AE32D4EDAC409B19A41 /* UIKit.framework */; };
+		4A19838FCCEEB877D0044609 /* ViewTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AC7315440692AACA1241582 /* ViewTestCase.swift */; };
+		5479D1C638618FA05262AAE5 /* Tempura.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 22F42FAD59238FD79B9C8F38 /* Tempura.framework */; };
+		5B6CD95C28339C832D3BBE95 /* DependenciesContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F7C530C657C5D77E6F65BEA /* DependenciesContainer.swift */; };
+		5B8670DD4BB3B89665A6549F /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C130AE32D4EDAC409B19A41 /* UIKit.framework */; };
+		5FD41A4BFFF656718C3FFDAC /* ViewControllerModellableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D30ACCB127637E1AC61B810 /* ViewControllerModellableView.swift */; };
+		62640D5C3BC1265ED855FEEA /* Media.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C35DA519D7C3EAA058B502D2 /* Media.xcassets */; };
+		6442760EEE874C7B086CABDB /* RootInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077C700F068523626965D032 /* RootInstaller.swift */; };
+		6752CCE8453D2481D2D7F1B0 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C60980B218A31D97B5C740 /* ViewController.swift */; };
+		6902A60816CC51C5C8C4A814 /* Tempura.h in Headers */ = {isa = PBXBuildFile; fileRef = 1972A28C80AD0240B932B09D /* Tempura.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6D769915D9FD627582137397 /* AddItemViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329D9008F24286E2426EF844 /* AddItemViewController.swift */; };
+		7050586D8609EF254C8CED85 /* Navigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66ED1355D2D21398BF7337F8 /* Navigator.swift */; };
+		7515EBCDA7D68B3D7D2A199A /* ViewController+Containment.swift in Sources */ = {isa = PBXBuildFile; fileRef = D851DBE506E398642D668DBD /* ViewController+Containment.swift */; };
+		78907D2EA385EDCBBFB66AC3 /* AppNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F1ECA92178B8C12065DCC51 /* AppNavigation.swift */; };
+		85D0FEE49166EA8743AE82C1 /* String+Height.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D09761FFA2A62CCDD51F39 /* String+Height.swift */; };
+		8B8A3C7D229764490703D96F /* UIControl+TargetActionable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BED3CE7EC5BF238848676947 /* UIControl+TargetActionable.swift */; };
+		8DA3B85E6E17DE0D33844C26 /* ChildViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3D0BE0D35273882E284B4A /* ChildViewController.swift */; };
+		911736DF89D7F9130BE9F9D6 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D173251D097C01031976550 /* Foundation.framework */; };
+		93BD31CBA21F108FCE2481AC /* Tempura.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 22F42FAD59238FD79B9C8F38 /* Tempura.framework */; };
+		956ECE61861A11B2D5A3CE6D /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7392B93FA131402229318FA /* Models.swift */; };
+		96F280DDF3B0F102319ABD06 /* MainThread.swift in Sources */ = {isa = PBXBuildFile; fileRef = D44679922AC4BA1E55D7C898 /* MainThread.swift */; };
+		98BADAA8B128C196BBF49216 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C130AE32D4EDAC409B19A41 /* UIKit.framework */; };
+		9B839B60261ABB64C993F98A /* View.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5971D51E106452553D4E716 /* View.swift */; };
+		A3566DEA66C3D53271E8F003 /* ArchiveFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31174697A6820D732C0114F3 /* ArchiveFlowLayout.swift */; };
+		A520426AD6FC3E6FCD494B5F /* TodoCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6403AEDD3987CCB131CDA75B /* TodoCell.swift */; };
+		A93F6A743B0D6A2EE43FE3A5 /* ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDAD825046D6676944EB496D /* ViewModel.swift */; };
+		A9618DC73EC28D4EDC359FD9 /* TextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A53E2964506D66472337355C /* TextView.swift */; };
+		AC2114E0CD7993C96F55AA82 /* ConfigurableCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A0326F9B3D7FAEED676E6B8 /* ConfigurableCell.swift */; };
+		ACAF6CF7BB336F6F4C3C24D1 /* ViewModelWithState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82673FC3F68B72629551548E /* ViewModelWithState.swift */; };
+		ADED57C54A077E3F0072BB5E /* AddItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C0141E40A3CE9B56587563E /* AddItemView.swift */; };
+		AE84FFACEAF2E603D0AB60C0 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D173251D097C01031976550 /* Foundation.framework */; };
+		B2B91BE43EE3B7C95787C49A /* Pods_DemoTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7CE77389AEDC7AACE8F428B6 /* Pods_DemoTests.framework */; };
+		B7270653DE261278782C65D6 /* ItemActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCA59D1B518AE32DC1182872 /* ItemActions.swift */; };
+		BB0F6E1EF56164AD23E9CFA5 /* Tempura.h in Headers */ = {isa = PBXBuildFile; fileRef = 1972A28C80AD0240B932B09D /* Tempura.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BFD48F41F7B6860E3D3AFEF1 /* DemoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DC50F0E5AA0F6C70373EBBC /* DemoTests.swift */; };
+		C337643FD022F28ED5FB9ED4 /* String+Random.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C41635DC286DF2EF82D3C98 /* String+Random.swift */; };
+		C4226C69E7034226F0E03463 /* Demo.app in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DDA36E967230883EF4E8D53 /* Demo.app */; };
+		C750F0055E4B59378AD66A9A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D173251D097C01031976550 /* Foundation.framework */; };
+		CDB0B03F11357A63FC30F8B0 /* ModellableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36CDB9B47C276D32D3CAC4E1 /* ModellableView.swift */; };
+		CE7E561A52732025016E9AE6 /* NavigationActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94990D7E78EEC74CFB590E9F /* NavigationActions.swift */; };
+		D4E73377102DB96BB9833A18 /* ListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73A14F07C2987E4988F7B67B /* ListView.swift */; };
+		D72356D6A3B6058127B8C734 /* CGRect+Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C66C8A5601E4511780C61F5 /* CGRect+Utils.swift */; };
+		DEF460E0E92A597D1F30B2CF /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D173251D097C01031976550 /* Foundation.framework */; };
+		E35A2FE46C66A7EABCD02CDD /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C130AE32D4EDAC409B19A41 /* UIKit.framework */; };
+		EB16DE1D7508E101CA6717D2 /* UIView+Blink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0052FBB63B9EBA6800D3C448 /* UIView+Blink.swift */; };
+		ED9DDF99494335BAFC5AE3F3 /* ViewModelWithLocalState.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF4B478A00B8BC136F2637BD /* ViewModelWithLocalState.swift */; };
+		F1517BD59DCF843518DBC5D3 /* ListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 907CF40A610C54C52D1E08FA /* ListViewController.swift */; };
+		F490CAA9033845F307B1E588 /* UITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F2056966CBA35070A5D350F /* UITests.swift */; };
+		F702A8D81AFA77CA0BBFACB3 /* TempuraTesting.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C943382F9E5F42B501C4B974 /* TempuraTesting.framework */; };
+		F949F2CAB9A6E4CAE6B17320 /* Pods_TempuraTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3B0C4A6AC40DD725C533233F /* Pods_TempuraTests.framework */; };
+		FA72ED0C5378180E05494A41 /* ViewControllerWithLocalState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64719E865F059693EFEE398A /* ViewControllerWithLocalState.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		89F207ECC961FDCBD91606F8 /* PBXContainerItemProxy */ = {
+		0079F4AE23BE7BCA0FBB1B39 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = D8A0132519FEF6C29B59D75F /* Project object */;
+			containerPortal = 8EC533182C3CFE067090F556 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 1892DB9BA2060E15764CAD26;
+			remoteGlobalIDString = 9A7B2C2C4784A31CB213B287;
+			remoteInfo = Tempura;
+		};
+		3E94D9AB36086D71D1FD3806 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8EC533182C3CFE067090F556 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F133CD648D5FA1083759D479;
 			remoteInfo = Demo;
 		};
-		949305310339F87701FC8E80 /* PBXContainerItemProxy */ = {
+		9E17CB8A8DE47C8A983B66F4 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = D8A0132519FEF6C29B59D75F /* Project object */;
+			containerPortal = 8EC533182C3CFE067090F556 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 938119F7066AAFEC015082C7;
+			remoteGlobalIDString = 9A7B2C2C4784A31CB213B287;
+			remoteInfo = Tempura;
+		};
+		AA4FDDB9F87D0DB5C9495E3F /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8EC533182C3CFE067090F556 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C3B2B96BE82BCDAED4C2C527;
 			remoteInfo = TempuraTesting;
-		};
-		A8C9EE0EFC1625F8C25984C9 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D8A0132519FEF6C29B59D75F /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 63F9441577436A029C256B73;
-			remoteInfo = Tempura;
-		};
-		C65C44281DE4235F6BF8172E /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D8A0132519FEF6C29B59D75F /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 63F9441577436A029C256B73;
-			remoteInfo = Tempura;
 		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		05D656105211F5F476174322 /* ViewControllerWithLocalStateSpec.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewControllerWithLocalStateSpec.swift; sourceTree = "<group>"; };
-		05DD995750DA2BD9101273AD /* UINavigationController+Completion.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "UINavigationController+Completion.swift"; sourceTree = "<group>"; };
-		066BD29BE68B0F984E18B070 /* ArchiveFlowLayout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ArchiveFlowLayout.swift; sourceTree = "<group>"; };
-		0C91621A472FB358A9175000 /* RootInstaller.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RootInstaller.swift; sourceTree = "<group>"; };
-		0D66306B4F49BB36F3AB7686 /* NavigationUtilities.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NavigationUtilities.swift; sourceTree = "<group>"; };
-		124087508DB9D22AEB329B68 /* ViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
-		17E667F0637D2D30AEDEC508 /* Pods-Tempura.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tempura.debug.xcconfig"; path = "Target Support Files/Pods-Tempura/Pods-Tempura.debug.xcconfig"; sourceTree = "<group>"; };
-		1B4FB4401B27E99C0304F6FC /* MainThread.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MainThread.swift; sourceTree = "<group>"; };
-		224F1C627264EA1E2C97572C /* Pods-Tempura-Demo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tempura-Demo.debug.xcconfig"; path = "Target Support Files/Pods-Tempura-Demo/Pods-Tempura-Demo.debug.xcconfig"; sourceTree = "<group>"; };
-		27ECB61436DEF80BE9F328ED /* NavigationActions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NavigationActions.swift; sourceTree = "<group>"; };
-		29A5058D1FD03E80F864E9BF /* UIControl+TargetActionable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "UIControl+TargetActionable.swift"; sourceTree = "<group>"; };
-		2E691D05957D60233CE5B495 /* String+Random.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "String+Random.swift"; sourceTree = "<group>"; };
-		2F98A7DFA046E3A07EE3A567 /* ViewController+Containment.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ViewController+Containment.swift"; sourceTree = "<group>"; };
-		34E120467BD6EC7E76E20896 /* TempuraTesting.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TempuraTesting.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		34FCBBA8101EF25F84AABBAD /* String+Height.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "String+Height.swift"; sourceTree = "<group>"; };
-		365C7ADAAD83E34B6DF33553 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.2.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		3B0746BC10A813F6C8778E79 /* Pods_DemoTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_DemoTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		3CE9616DD53A600BD4B573C5 /* Demo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Demo.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		3D6D4F6DC99F26CDBEA1289D /* Routable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Routable.swift; sourceTree = "<group>"; };
-		3DF32F34E08702F9882D112A /* Pods_Tempura_Demo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Tempura_Demo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		3E74774ED639DCDB10E992BB /* Models.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Models.swift; sourceTree = "<group>"; };
-		41527ABF1B6837B8AF7F3328 /* DependenciesContainer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DependenciesContainer.swift; sourceTree = "<group>"; };
-		430BEB8CA3EBCB7533735974 /* UIView+Blink.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "UIView+Blink.swift"; sourceTree = "<group>"; };
-		4D667185BCE5059D0229114C /* TodoCell.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TodoCell.swift; sourceTree = "<group>"; };
-		4EA052C0323E0CF37B855B51 /* Pods_TempuraTesting.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TempuraTesting.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		5438311309EEE332B044EF76 /* CollectionView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CollectionView.swift; sourceTree = "<group>"; };
-		57E833A490FB237B32F8D704 /* Navigator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Navigator.swift; sourceTree = "<group>"; };
-		5C1C6325FC531AA4683C33DC /* Pods-TempuraTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TempuraTests.debug.xcconfig"; path = "Target Support Files/Pods-TempuraTests/Pods-TempuraTests.debug.xcconfig"; sourceTree = "<group>"; };
-		5DAE92FF322ADFE9FD055FB9 /* Pods_Tempura.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Tempura.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		61E6704CB2184446DCDE6994 /* TempuraTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TempuraTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		63049672E490DD80E4AB15EB /* ViewModelWithState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewModelWithState.swift; sourceTree = "<group>"; };
-		63B570D57882BFAD423B25C7 /* Pods-Tempura.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tempura.release.xcconfig"; path = "Target Support Files/Pods-Tempura/Pods-Tempura.release.xcconfig"; sourceTree = "<group>"; };
-		691B5AAF78D0ABFF0B97FC1D /* ChildViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ChildViewController.swift; sourceTree = "<group>"; };
-		6CBE957E5809A4C35ED1257C /* AddItemViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AddItemViewController.swift; sourceTree = "<group>"; };
-		6FD9C11902C24A2C9AAE0157 /* ViewControllerModellableView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewControllerModellableView.swift; sourceTree = "<group>"; };
-		797C94A33B6035CB3FC26C2C /* ModellableView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ModellableView.swift; sourceTree = "<group>"; };
-		7CFCE2875FC533BDF567B430 /* ViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewModel.swift; sourceTree = "<group>"; };
-		7E0E3BFA3212CC179BC4F929 /* Source.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Source.swift; sourceTree = "<group>"; };
-		854D7436C27D2BFB638F66FE /* ViewControllerWithLocalState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewControllerWithLocalState.swift; sourceTree = "<group>"; };
-		86701B6C0EDB65EDEB07806B /* ViewTestCase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewTestCase.swift; sourceTree = "<group>"; };
-		87E4C6ABC71FC1664E4FF861 /* ViewControllerContainmentSpec.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewControllerContainmentSpec.swift; sourceTree = "<group>"; };
-		8BD45992CF402F8F79775E8E /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.2.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
-		8BFB631A233B1C211DA7E781 /* Pods-TempuraTesting.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TempuraTesting.debug.xcconfig"; path = "Target Support Files/Pods-TempuraTesting/Pods-TempuraTesting.debug.xcconfig"; sourceTree = "<group>"; };
-		8DE0220F6B220A8E272E2D8F /* ViewControllerTestCase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewControllerTestCase.swift; sourceTree = "<group>"; };
-		8FA45BAC76F4311D4BFB27B3 /* Pods-TempuraTesting.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TempuraTesting.release.xcconfig"; path = "Target Support Files/Pods-TempuraTesting/Pods-TempuraTesting.release.xcconfig"; sourceTree = "<group>"; };
-		95F5BF15B3ADE7E7D80F6133 /* NavigationDSL.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NavigationDSL.swift; sourceTree = "<group>"; };
-		967CEE8572EC809D3CCEBBD4 /* Pods-DemoTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DemoTests.release.xcconfig"; path = "Target Support Files/Pods-DemoTests/Pods-DemoTests.release.xcconfig"; sourceTree = "<group>"; };
-		9E5D2185CF44CE41AE3F02EF /* ItemActions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ItemActions.swift; sourceTree = "<group>"; };
-		A4EFE88F3C638250463B4FA2 /* TodoFlowLayout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TodoFlowLayout.swift; sourceTree = "<group>"; };
-		A73CEBBED3723AB91E50AD43 /* UITests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UITests.swift; sourceTree = "<group>"; };
-		A8872EF76E2782A6E0014500 /* AppState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
-		ABEBC105FBB3704C0A040991 /* LocalState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LocalState.swift; sourceTree = "<group>"; };
-		B2FEAC4E5310B1CBD272137E /* ConfigurableCell.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConfigurableCell.swift; sourceTree = "<group>"; };
-		B8AA42C6C293381338E9D420 /* Pods-DemoTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DemoTests.debug.xcconfig"; path = "Target Support Files/Pods-DemoTests/Pods-DemoTests.debug.xcconfig"; sourceTree = "<group>"; };
-		BAC722305AF44A222379BEE0 /* CGRect+Utils.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "CGRect+Utils.swift"; sourceTree = "<group>"; };
-		BDC31BA2BF86D2680A23E319 /* Tempura.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = Tempura.h; sourceTree = "<group>"; };
-		C236F14F6AA046203BB0750F /* DemoTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DemoTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		C2F4D5205058D032237FF3E0 /* DemoTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DemoTests.swift; sourceTree = "<group>"; };
-		C55863BDC39902606A38256C /* NavigationProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NavigationProvider.swift; sourceTree = "<group>"; };
-		C5606D63EECCE87514317710 /* ViewModelWithLocalState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewModelWithLocalState.swift; sourceTree = "<group>"; };
-		C74724C0E93FB2E2E0711EA1 /* Pods_TempuraTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TempuraTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		CBC2ABC900303DE2866BF967 /* ViewControllerSpec.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewControllerSpec.swift; sourceTree = "<group>"; };
-		CD88C54DB088501AE41771FC /* Media.xcassets */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder.assetcatalog; path = Media.xcassets; sourceTree = "<group>"; };
-		D18A416893AB0479B28B8986 /* View.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = View.swift; sourceTree = "<group>"; };
-		D3926C5BF6087C1B041B958B /* AppNavigation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppNavigation.swift; sourceTree = "<group>"; };
-		DB477FF662BDDB587C628AFA /* DataSource.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DataSource.swift; sourceTree = "<group>"; };
-		E4EF07632466F97B507ED75A /* Pods-TempuraTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TempuraTests.release.xcconfig"; path = "Target Support Files/Pods-TempuraTests/Pods-TempuraTests.release.xcconfig"; sourceTree = "<group>"; };
-		E9DA70412AAC2D7B68E1D8E8 /* AppDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		EABFD66BC29C2F8C9454A4FA /* TextView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TextView.swift; sourceTree = "<group>"; };
-		EAC29BB68511803008671B81 /* ListViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ListViewController.swift; sourceTree = "<group>"; };
-		EC2AB3843ABFFEF783B2FA36 /* ListView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ListView.swift; sourceTree = "<group>"; };
-		EED1692C3B2CB9E16B5C8E3A /* Pods-Tempura-Demo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tempura-Demo.release.xcconfig"; path = "Target Support Files/Pods-Tempura-Demo/Pods-Tempura-Demo.release.xcconfig"; sourceTree = "<group>"; };
-		F59068F107DD5A8AE4AF7FC3 /* LocalFileURLProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LocalFileURLProtocol.swift; sourceTree = "<group>"; };
-		F8AC45BAB0DC56AA13EBEB62 /* Tempura.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Tempura.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		FC727A979E70A5B2A5D11384 /* UIView+snapshot.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "UIView+snapshot.swift"; sourceTree = "<group>"; };
-		FE0738530729F8CEFFFB883A /* AddItemView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AddItemView.swift; sourceTree = "<group>"; };
+		0052FBB63B9EBA6800D3C448 /* UIView+Blink.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "UIView+Blink.swift"; sourceTree = "<group>"; };
+		03207435C27B3BA015183220 /* DemoTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DemoTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		04C60980B218A31D97B5C740 /* ViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		077C700F068523626965D032 /* RootInstaller.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RootInstaller.swift; sourceTree = "<group>"; };
+		0D79233B0CEED31350194F1C /* Pods-Tempura.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tempura.release.xcconfig"; path = "Target Support Files/Pods-Tempura/Pods-Tempura.release.xcconfig"; sourceTree = "<group>"; };
+		0F1ECA92178B8C12065DCC51 /* AppNavigation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppNavigation.swift; sourceTree = "<group>"; };
+		1072A73394C9DE763373F81E /* Pods-Tempura.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tempura.debug.xcconfig"; path = "Target Support Files/Pods-Tempura/Pods-Tempura.debug.xcconfig"; sourceTree = "<group>"; };
+		164B34F6CD3CF5FEEB1FD5B3 /* Source.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Source.swift; sourceTree = "<group>"; };
+		184B014CD1FFE92F896DFC30 /* ViewControllerWithLocalStateSpec.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewControllerWithLocalStateSpec.swift; sourceTree = "<group>"; };
+		1972A28C80AD0240B932B09D /* Tempura.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = Tempura.h; sourceTree = "<group>"; };
+		1D173251D097C01031976550 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.2.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		1DDA36E967230883EF4E8D53 /* Demo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Demo.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		1FD1C4CAC97F75A7333C7D72 /* Pods_Tempura.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Tempura.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		20D09761FFA2A62CCDD51F39 /* String+Height.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "String+Height.swift"; sourceTree = "<group>"; };
+		22F42FAD59238FD79B9C8F38 /* Tempura.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Tempura.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		2C0141E40A3CE9B56587563E /* AddItemView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AddItemView.swift; sourceTree = "<group>"; };
+		2F2056966CBA35070A5D350F /* UITests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UITests.swift; sourceTree = "<group>"; };
+		31174697A6820D732C0114F3 /* ArchiveFlowLayout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ArchiveFlowLayout.swift; sourceTree = "<group>"; };
+		329D9008F24286E2426EF844 /* AddItemViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AddItemViewController.swift; sourceTree = "<group>"; };
+		36226BAB6DE2963229C3C853 /* Routable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Routable.swift; sourceTree = "<group>"; };
+		36CDB9B47C276D32D3CAC4E1 /* ModellableView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ModellableView.swift; sourceTree = "<group>"; };
+		3B0C4A6AC40DD725C533233F /* Pods_TempuraTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TempuraTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		3C41635DC286DF2EF82D3C98 /* String+Random.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "String+Random.swift"; sourceTree = "<group>"; };
+		3C66C8A5601E4511780C61F5 /* CGRect+Utils.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "CGRect+Utils.swift"; sourceTree = "<group>"; };
+		3E85CCD29540E3DEE2DA87F0 /* Pods-Tempura-Demo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tempura-Demo.debug.xcconfig"; path = "Target Support Files/Pods-Tempura-Demo/Pods-Tempura-Demo.debug.xcconfig"; sourceTree = "<group>"; };
+		3F7C530C657C5D77E6F65BEA /* DependenciesContainer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DependenciesContainer.swift; sourceTree = "<group>"; };
+		4267731146963574851DAFC7 /* NavigationDSL.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NavigationDSL.swift; sourceTree = "<group>"; };
+		44FDD6974A9AAE917A1B84A3 /* LocalState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LocalState.swift; sourceTree = "<group>"; };
+		4A0326F9B3D7FAEED676E6B8 /* ConfigurableCell.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConfigurableCell.swift; sourceTree = "<group>"; };
+		4D30ACCB127637E1AC61B810 /* ViewControllerModellableView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewControllerModellableView.swift; sourceTree = "<group>"; };
+		5564081DF13E2DCA4A754F66 /* NavigationUtilities.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NavigationUtilities.swift; sourceTree = "<group>"; };
+		569E390CCB8B0146A15D1AEB /* Pods-TempuraTesting.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TempuraTesting.debug.xcconfig"; path = "Target Support Files/Pods-TempuraTesting/Pods-TempuraTesting.debug.xcconfig"; sourceTree = "<group>"; };
+		5A237D4BC151C98EDE2190FD /* CollectionView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CollectionView.swift; sourceTree = "<group>"; };
+		5AFC07783E89FF67C96D2EB4 /* Pods-Tempura-Demo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tempura-Demo.release.xcconfig"; path = "Target Support Files/Pods-Tempura-Demo/Pods-Tempura-Demo.release.xcconfig"; sourceTree = "<group>"; };
+		5C130AE32D4EDAC409B19A41 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.2.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
+		5DCF78D34AC9F62FB9A391C4 /* TodoFlowLayout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TodoFlowLayout.swift; sourceTree = "<group>"; };
+		611BBDB76D0812419D552DD7 /* NavigationProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NavigationProvider.swift; sourceTree = "<group>"; };
+		6403AEDD3987CCB131CDA75B /* TodoCell.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TodoCell.swift; sourceTree = "<group>"; };
+		64719E865F059693EFEE398A /* ViewControllerWithLocalState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewControllerWithLocalState.swift; sourceTree = "<group>"; };
+		66ED1355D2D21398BF7337F8 /* Navigator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Navigator.swift; sourceTree = "<group>"; };
+		73A14F07C2987E4988F7B67B /* ListView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ListView.swift; sourceTree = "<group>"; };
+		7A5C33BAFA60225650D6B732 /* ViewControllerSpec.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewControllerSpec.swift; sourceTree = "<group>"; };
+		7CE77389AEDC7AACE8F428B6 /* Pods_DemoTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_DemoTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		7F8048FD19E805306CFC1017 /* Pods-TempuraTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TempuraTests.release.xcconfig"; path = "Target Support Files/Pods-TempuraTests/Pods-TempuraTests.release.xcconfig"; sourceTree = "<group>"; };
+		819DAD0969CDCE437CAE1FCD /* Pods_TempuraTesting.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TempuraTesting.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		82673FC3F68B72629551548E /* ViewModelWithState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewModelWithState.swift; sourceTree = "<group>"; };
+		8DC50F0E5AA0F6C70373EBBC /* DemoTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DemoTests.swift; sourceTree = "<group>"; };
+		907CF40A610C54C52D1E08FA /* ListViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ListViewController.swift; sourceTree = "<group>"; };
+		93A2E715A24EA2BD61386830 /* UINavigationController+Completion.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "UINavigationController+Completion.swift"; sourceTree = "<group>"; };
+		94990D7E78EEC74CFB590E9F /* NavigationActions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NavigationActions.swift; sourceTree = "<group>"; };
+		995545296A8A7AE7E8D58645 /* AppDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		9AC7315440692AACA1241582 /* ViewTestCase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewTestCase.swift; sourceTree = "<group>"; };
+		9D703ADC8E96A5B1810899F7 /* DataSource.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DataSource.swift; sourceTree = "<group>"; };
+		A53E2964506D66472337355C /* TextView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TextView.swift; sourceTree = "<group>"; };
+		AF4B478A00B8BC136F2637BD /* ViewModelWithLocalState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewModelWithLocalState.swift; sourceTree = "<group>"; };
+		B57588FD20A78D0F349A51D0 /* Pods_Tempura_Demo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Tempura_Demo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B9E1399C697BC5EEF942A3CF /* ViewControllerTestCase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewControllerTestCase.swift; sourceTree = "<group>"; };
+		BCA59D1B518AE32DC1182872 /* ItemActions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ItemActions.swift; sourceTree = "<group>"; };
+		BED3CE7EC5BF238848676947 /* UIControl+TargetActionable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "UIControl+TargetActionable.swift"; sourceTree = "<group>"; };
+		C35DA519D7C3EAA058B502D2 /* Media.xcassets */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder.assetcatalog; path = Media.xcassets; sourceTree = "<group>"; };
+		C5971D51E106452553D4E716 /* View.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = View.swift; sourceTree = "<group>"; };
+		C8EA6B9D00FA578ACCF03D70 /* Pods-DemoTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DemoTests.debug.xcconfig"; path = "Target Support Files/Pods-DemoTests/Pods-DemoTests.debug.xcconfig"; sourceTree = "<group>"; };
+		C943382F9E5F42B501C4B974 /* TempuraTesting.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TempuraTesting.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		CA3EC8FDEE4DC2807E9E72F6 /* UIView+snapshot.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "UIView+snapshot.swift"; sourceTree = "<group>"; };
+		CBD200BDEA2EBF67BD1164F3 /* TempuraTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TempuraTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		CDAD825046D6676944EB496D /* ViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewModel.swift; sourceTree = "<group>"; };
+		D44679922AC4BA1E55D7C898 /* MainThread.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MainThread.swift; sourceTree = "<group>"; };
+		D851DBE506E398642D668DBD /* ViewController+Containment.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ViewController+Containment.swift"; sourceTree = "<group>"; };
+		DE3D0BE0D35273882E284B4A /* ChildViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ChildViewController.swift; sourceTree = "<group>"; };
+		E202D263AC91E57EF107CE6F /* AppState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
+		E46224FFEBC481FA50279FEE /* LocalFileURLProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LocalFileURLProtocol.swift; sourceTree = "<group>"; };
+		E7392B93FA131402229318FA /* Models.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Models.swift; sourceTree = "<group>"; };
+		F29DBB122D76B66BE9B82FEF /* Pods-DemoTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DemoTests.release.xcconfig"; path = "Target Support Files/Pods-DemoTests/Pods-DemoTests.release.xcconfig"; sourceTree = "<group>"; };
+		F6D5BC69D3350D1B9D715C3C /* ViewControllerContainmentSpec.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewControllerContainmentSpec.swift; sourceTree = "<group>"; };
+		F70BA8019F66F30D9FFAB9F0 /* Pods-TempuraTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TempuraTests.debug.xcconfig"; path = "Target Support Files/Pods-TempuraTests/Pods-TempuraTests.debug.xcconfig"; sourceTree = "<group>"; };
+		F86D79A5717CA3800CF3EAC9 /* Pods-TempuraTesting.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TempuraTesting.release.xcconfig"; path = "Target Support Files/Pods-TempuraTesting/Pods-TempuraTesting.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		214970ED9788985D0BEA553A /* Frameworks */ = {
+		35518798597B8C933686910D /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				286E70FC894B769127E6144F /* Foundation.framework in Frameworks */,
-				97DB015BCAA5F55641DED7ED /* UIKit.framework in Frameworks */,
-				0311E6E7C788907865D30EAC /* Pods_TempuraTesting.framework in Frameworks */,
+				C4226C69E7034226F0E03463 /* Demo.app in Frameworks */,
+				F702A8D81AFA77CA0BBFACB3 /* TempuraTesting.framework in Frameworks */,
+				911736DF89D7F9130BE9F9D6 /* Foundation.framework in Frameworks */,
+				98BADAA8B128C196BBF49216 /* UIKit.framework in Frameworks */,
+				B2B91BE43EE3B7C95787C49A /* Pods_DemoTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		36109B4AA647D79EA72BA81D /* Frameworks */ = {
+		3565D5C367159A3C3BD55263 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				720FF52E09111A777003474D /* Tempura.framework in Frameworks */,
-				FE96643D9C93BB72A767AD3F /* Foundation.framework in Frameworks */,
-				29A75BED0EF5A827341EB73A /* UIKit.framework in Frameworks */,
-				56DE6F862E7EE0A1D260C757 /* Pods_Tempura_Demo.framework in Frameworks */,
+				93BD31CBA21F108FCE2481AC /* Tempura.framework in Frameworks */,
+				3374D1553431F02B994DEED7 /* Foundation.framework in Frameworks */,
+				2C03CB7A775BB3E56B70CDE8 /* UIKit.framework in Frameworks */,
+				F949F2CAB9A6E4CAE6B17320 /* Pods_TempuraTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		5E20147194A6A188203E353B /* Frameworks */ = {
+		762686097E1040E223C59852 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A6FEDEECDBA174CAAA5DAEF5 /* Demo.app in Frameworks */,
-				D6D9BD3DA0FD0307B6F62D13 /* TempuraTesting.framework in Frameworks */,
-				8A669B6A2402C681AD7B22F8 /* Foundation.framework in Frameworks */,
-				84DFEBDA0709D7840369EB21 /* UIKit.framework in Frameworks */,
-				8BF4A2ACC316A3AEF31E0550 /* Pods_DemoTests.framework in Frameworks */,
+				5479D1C638618FA05262AAE5 /* Tempura.framework in Frameworks */,
+				DEF460E0E92A597D1F30B2CF /* Foundation.framework in Frameworks */,
+				E35A2FE46C66A7EABCD02CDD /* UIKit.framework in Frameworks */,
+				1F34C5E853BCC8427875CAE6 /* Pods_Tempura_Demo.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		E5F6C7A182607320ADB3E7BC /* Frameworks */ = {
+		8478B7BA0BA582B57D5F2951 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F3B3E7802187CC374D623BD2 /* Tempura.framework in Frameworks */,
-				85A86393FC0E407A8928F9E3 /* Foundation.framework in Frameworks */,
-				0F545B381C8FBACB79C6067A /* UIKit.framework in Frameworks */,
-				6EA7FD807A80F89EE7FD1464 /* Pods_TempuraTests.framework in Frameworks */,
+				C750F0055E4B59378AD66A9A /* Foundation.framework in Frameworks */,
+				5B8670DD4BB3B89665A6549F /* UIKit.framework in Frameworks */,
+				1E87CEDD2938DAA2CA3945A6 /* Pods_TempuraTesting.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		F8324919E965E45D728A15AA /* Frameworks */ = {
+		ECD81D2555899EAB13A3A2BE /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				516DC45C7356957DC7AF6650 /* Foundation.framework in Frameworks */,
-				6FE6DDC49215D6D17365B887 /* UIKit.framework in Frameworks */,
-				9666B94F1723376D83513E19 /* Pods_Tempura.framework in Frameworks */,
+				AE84FFACEAF2E603D0AB60C0 /* Foundation.framework in Frameworks */,
+				43C7C5BE9F0ECA33A60D5357 /* UIKit.framework in Frameworks */,
+				4097B99BD8B9A0C8E766B5AF /* Pods_Tempura.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		035C4F9407AF90A82B8DCCC8 /* State */ = {
+		0A2AB5A994B868D3D198342B /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
-				A8872EF76E2782A6E0014500 /* AppState.swift */,
-				3E74774ED639DCDB10E992BB /* Models.swift */,
+				D44679922AC4BA1E55D7C898 /* MainThread.swift */,
 			);
-			name = State;
-			path = State;
+			name = Utilities;
+			path = Utilities;
 			sourceTree = "<group>";
 		};
-		11D582AB38AA412F8B688623 /* UI */ = {
+		22187D0F5197DABDFDD21723 /* AddItemScreen */ = {
 			isa = PBXGroup;
 			children = (
-				9F57A50F709872C5123F479D /* ListScreen */,
-				4A30A23AC3CB595F24B3AA0F /* AddItemScreen */,
-			);
-			name = UI;
-			path = UI;
-			sourceTree = "<group>";
-		};
-		18BF3EE3510C9B6E675F7943 /* Actions */ = {
-			isa = PBXGroup;
-			children = (
-				9E5D2185CF44CE41AE3F02EF /* ItemActions.swift */,
-			);
-			name = Actions;
-			path = Actions;
-			sourceTree = "<group>";
-		};
-		18C53DD08BA27BBF77E1A688 /* Dependencies */ = {
-			isa = PBXGroup;
-			children = (
-				41527ABF1B6837B8AF7F3328 /* DependenciesContainer.swift */,
-			);
-			name = Dependencies;
-			path = Dependencies;
-			sourceTree = "<group>";
-		};
-		1943195B89D5A06EF46B12D9 /* Navigation */ = {
-			isa = PBXGroup;
-			children = (
-				D3926C5BF6087C1B041B958B /* AppNavigation.swift */,
-			);
-			name = Navigation;
-			path = Navigation;
-			sourceTree = "<group>";
-		};
-		1ADE483B5E121ABCC45567C5 /* Navigation */ = {
-			isa = PBXGroup;
-			children = (
-				05DD995750DA2BD9101273AD /* UINavigationController+Completion.swift */,
-				27ECB61436DEF80BE9F328ED /* NavigationActions.swift */,
-				0D66306B4F49BB36F3AB7686 /* NavigationUtilities.swift */,
-				3D6D4F6DC99F26CDBEA1289D /* Routable.swift */,
-				0C91621A472FB358A9175000 /* RootInstaller.swift */,
-				95F5BF15B3ADE7E7D80F6133 /* NavigationDSL.swift */,
-				C55863BDC39902606A38256C /* NavigationProvider.swift */,
-				57E833A490FB237B32F8D704 /* Navigator.swift */,
-			);
-			name = Navigation;
-			path = Navigation;
-			sourceTree = "<group>";
-		};
-		1FE014E20665700677D68354 /* iOS */ = {
-			isa = PBXGroup;
-			children = (
-				365C7ADAAD83E34B6DF33553 /* Foundation.framework */,
-				8BD45992CF402F8F79775E8E /* UIKit.framework */,
-			);
-			name = iOS;
-			sourceTree = "<group>";
-		};
-		2BAB6EDCA29E04B078790597 /* Core */ = {
-			isa = PBXGroup;
-			children = (
-				124087508DB9D22AEB329B68 /* ViewController.swift */,
-				D18A416893AB0479B28B8986 /* View.swift */,
-				63049672E490DD80E4AB15EB /* ViewModelWithState.swift */,
-				797C94A33B6035CB3FC26C2C /* ModellableView.swift */,
-				C5606D63EECCE87514317710 /* ViewModelWithLocalState.swift */,
-				ABEBC105FBB3704C0A040991 /* LocalState.swift */,
-				7CFCE2875FC533BDF567B430 /* ViewModel.swift */,
-				6FD9C11902C24A2C9AAE0157 /* ViewControllerModellableView.swift */,
-				854D7436C27D2BFB638F66FE /* ViewControllerWithLocalState.swift */,
-				2F98A7DFA046E3A07EE3A567 /* ViewController+Containment.swift */,
-			);
-			name = Core;
-			path = Core;
-			sourceTree = "<group>";
-		};
-		312C471CD4DC0C718205D294 /* SupportingFiles */ = {
-			isa = PBXGroup;
-			children = (
-				BDC31BA2BF86D2680A23E319 /* Tempura.h */,
-			);
-			name = SupportingFiles;
-			path = SupportingFiles;
-			sourceTree = "<group>";
-		};
-		36F10A5BC0BA9D6B7D8BA5E7 /* CollectionView */ = {
-			isa = PBXGroup;
-			children = (
-				7E0E3BFA3212CC179BC4F929 /* Source.swift */,
-				5438311309EEE332B044EF76 /* CollectionView.swift */,
-				DB477FF662BDDB587C628AFA /* DataSource.swift */,
-				B2FEAC4E5310B1CBD272137E /* ConfigurableCell.swift */,
-			);
-			name = CollectionView;
-			path = CollectionView;
-			sourceTree = "<group>";
-		};
-		4050D36DCED3A30B6B882E9F /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				61E6704CB2184446DCDE6994 /* TempuraTests.xctest */,
-				F8AC45BAB0DC56AA13EBEB62 /* Tempura.framework */,
-				34E120467BD6EC7E76E20896 /* TempuraTesting.framework */,
-				C236F14F6AA046203BB0750F /* DemoTests.xctest */,
-				3CE9616DD53A600BD4B573C5 /* Demo.app */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		4A30A23AC3CB595F24B3AA0F /* AddItemScreen */ = {
-			isa = PBXGroup;
-			children = (
-				EEFF1DA88C4AB4C00FF5A7BA /* Subviews */,
-				FE0738530729F8CEFFFB883A /* AddItemView.swift */,
-				6CBE957E5809A4C35ED1257C /* AddItemViewController.swift */,
+				A11A7BCA2DC4D9DBFFF1306B /* Subviews */,
+				2C0141E40A3CE9B56587563E /* AddItemView.swift */,
+				329D9008F24286E2426EF844 /* AddItemViewController.swift */,
 			);
 			name = AddItemScreen;
 			path = AddItemScreen;
 			sourceTree = "<group>";
 		};
-		580F5EDE0F698F5AEDA229F6 /* Pods */ = {
+		342DDB226674F5396F52B853 /* Core */ = {
 			isa = PBXGroup;
 			children = (
-				B8AA42C6C293381338E9D420 /* Pods-DemoTests.debug.xcconfig */,
-				967CEE8572EC809D3CCEBBD4 /* Pods-DemoTests.release.xcconfig */,
-				17E667F0637D2D30AEDEC508 /* Pods-Tempura.debug.xcconfig */,
-				63B570D57882BFAD423B25C7 /* Pods-Tempura.release.xcconfig */,
-				224F1C627264EA1E2C97572C /* Pods-Tempura-Demo.debug.xcconfig */,
-				EED1692C3B2CB9E16B5C8E3A /* Pods-Tempura-Demo.release.xcconfig */,
-				8BFB631A233B1C211DA7E781 /* Pods-TempuraTesting.debug.xcconfig */,
-				8FA45BAC76F4311D4BFB27B3 /* Pods-TempuraTesting.release.xcconfig */,
-				5C1C6325FC531AA4683C33DC /* Pods-TempuraTests.debug.xcconfig */,
-				E4EF07632466F97B507ED75A /* Pods-TempuraTests.release.xcconfig */,
+				04C60980B218A31D97B5C740 /* ViewController.swift */,
+				C5971D51E106452553D4E716 /* View.swift */,
+				82673FC3F68B72629551548E /* ViewModelWithState.swift */,
+				36CDB9B47C276D32D3CAC4E1 /* ModellableView.swift */,
+				AF4B478A00B8BC136F2637BD /* ViewModelWithLocalState.swift */,
+				44FDD6974A9AAE917A1B84A3 /* LocalState.swift */,
+				CDAD825046D6676944EB496D /* ViewModel.swift */,
+				4D30ACCB127637E1AC61B810 /* ViewControllerModellableView.swift */,
+				64719E865F059693EFEE398A /* ViewControllerWithLocalState.swift */,
+				D851DBE506E398642D668DBD /* ViewController+Containment.swift */,
 			);
-			name = Pods;
-			path = Pods;
+			name = Core;
+			path = Core;
 			sourceTree = "<group>";
 		};
-		620CBF7617A06D921FFE214F /* Utilities */ = {
+		435A4657730A540501BB0086 /* Subviews */ = {
 			isa = PBXGroup;
 			children = (
-				29A5058D1FD03E80F864E9BF /* UIControl+TargetActionable.swift */,
-				2E691D05957D60233CE5B495 /* String+Random.swift */,
-				36F10A5BC0BA9D6B7D8BA5E7 /* CollectionView */,
-				BAC722305AF44A222379BEE0 /* CGRect+Utils.swift */,
-				430BEB8CA3EBCB7533735974 /* UIView+Blink.swift */,
-				34FCBBA8101EF25F84AABBAD /* String+Height.swift */,
+				31174697A6820D732C0114F3 /* ArchiveFlowLayout.swift */,
+				6403AEDD3987CCB131CDA75B /* TodoCell.swift */,
+				5DCF78D34AC9F62FB9A391C4 /* TodoFlowLayout.swift */,
 			);
-			name = Utilities;
-			path = Utilities;
+			name = Subviews;
+			path = Subviews;
 			sourceTree = "<group>";
 		};
-		748DEEF0C285CCA982F8F585 /* Demo */ = {
+		46B3F0C5FBAF55F9CDC085F9 /* Tempura */ = {
 			isa = PBXGroup;
 			children = (
-				11D582AB38AA412F8B688623 /* UI */,
-				1943195B89D5A06EF46B12D9 /* Navigation */,
-				18C53DD08BA27BBF77E1A688 /* Dependencies */,
-				035C4F9407AF90A82B8DCCC8 /* State */,
-				620CBF7617A06D921FFE214F /* Utilities */,
-				18BF3EE3510C9B6E675F7943 /* Actions */,
-				D26ED15FB34355CC0353B89C /* Application */,
-				BBC8585E34EF4FAF64D72F67 /* Resources */,
-			);
-			name = Demo;
-			path = Demo;
-			sourceTree = "<group>";
-		};
-		75A9E4B1DE66700042956C8C /* Tempura */ = {
-			isa = PBXGroup;
-			children = (
-				2BAB6EDCA29E04B078790597 /* Core */,
-				1ADE483B5E121ABCC45567C5 /* Navigation */,
-				7CA45630C6B39B2180BA0352 /* Utilities */,
-				CF28E6D7AC8158BB8D3E469A /* UITests */,
-				312C471CD4DC0C718205D294 /* SupportingFiles */,
+				342DDB226674F5396F52B853 /* Core */,
+				DD2A773F944A89F1F1496F66 /* Navigation */,
+				0A2AB5A994B868D3D198342B /* Utilities */,
+				8D210A56029AE558547CFC51 /* UITests */,
+				E27B94DF3BF41203FDDBDA8C /* SupportingFiles */,
 			);
 			name = Tempura;
 			path = Tempura;
 			sourceTree = "<group>";
 		};
-		7CA45630C6B39B2180BA0352 /* Utilities */ = {
+		584F31C62524439AF2DEBAE9 = {
 			isa = PBXGroup;
 			children = (
-				1B4FB4401B27E99C0304F6FC /* MainThread.swift */,
+				CDACA981441DBC60BA6B6065 /* Products */,
+				74E07E6BC052C901A396F51F /* Frameworks */,
+				7CAE0F10FD257B249FC0B3F2 /* TempuraTests */,
+				46B3F0C5FBAF55F9CDC085F9 /* Tempura */,
+				AEFA00A76C63B755867294DC /* DemoTests */,
+				8A60C4D58F4FEC199CEEB6C6 /* Demo */,
+				5EEAF698D76C5CDDD68237AF /* Pods */,
+			);
+			sourceTree = "<group>";
+		};
+		5AD2AD3801E1145FF2FD2872 /* Utilities */ = {
+			isa = PBXGroup;
+			children = (
+				BED3CE7EC5BF238848676947 /* UIControl+TargetActionable.swift */,
+				3C41635DC286DF2EF82D3C98 /* String+Random.swift */,
+				CE50A14BB02040C75E6353F3 /* CollectionView */,
+				3C66C8A5601E4511780C61F5 /* CGRect+Utils.swift */,
+				0052FBB63B9EBA6800D3C448 /* UIView+Blink.swift */,
+				20D09761FFA2A62CCDD51F39 /* String+Height.swift */,
 			);
 			name = Utilities;
 			path = Utilities;
 			sourceTree = "<group>";
 		};
-		8904F63DB146ADB80B75F8EB /* Frameworks */ = {
+		5EEAF698D76C5CDDD68237AF /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				1FE014E20665700677D68354 /* iOS */,
-				3B0746BC10A813F6C8778E79 /* Pods_DemoTests.framework */,
-				5DAE92FF322ADFE9FD055FB9 /* Pods_Tempura.framework */,
-				3DF32F34E08702F9882D112A /* Pods_Tempura_Demo.framework */,
-				4EA052C0323E0CF37B855B51 /* Pods_TempuraTesting.framework */,
-				C74724C0E93FB2E2E0711EA1 /* Pods_TempuraTests.framework */,
+				C8EA6B9D00FA578ACCF03D70 /* Pods-DemoTests.debug.xcconfig */,
+				F29DBB122D76B66BE9B82FEF /* Pods-DemoTests.release.xcconfig */,
+				1072A73394C9DE763373F81E /* Pods-Tempura.debug.xcconfig */,
+				0D79233B0CEED31350194F1C /* Pods-Tempura.release.xcconfig */,
+				3E85CCD29540E3DEE2DA87F0 /* Pods-Tempura-Demo.debug.xcconfig */,
+				5AFC07783E89FF67C96D2EB4 /* Pods-Tempura-Demo.release.xcconfig */,
+				569E390CCB8B0146A15D1AEB /* Pods-TempuraTesting.debug.xcconfig */,
+				F86D79A5717CA3800CF3EAC9 /* Pods-TempuraTesting.release.xcconfig */,
+				F70BA8019F66F30D9FFAB9F0 /* Pods-TempuraTests.debug.xcconfig */,
+				7F8048FD19E805306CFC1017 /* Pods-TempuraTests.release.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
+			sourceTree = "<group>";
+		};
+		74E07E6BC052C901A396F51F /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				94F1688C69043B613C7BE9DE /* iOS */,
+				7CE77389AEDC7AACE8F428B6 /* Pods_DemoTests.framework */,
+				1FD1C4CAC97F75A7333C7D72 /* Pods_Tempura.framework */,
+				B57588FD20A78D0F349A51D0 /* Pods_Tempura_Demo.framework */,
+				819DAD0969CDCE437CAE1FCD /* Pods_TempuraTesting.framework */,
+				3B0C4A6AC40DD725C533233F /* Pods_TempuraTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		91A745937C1DA6F5EB1D068E /* Subviews */ = {
+		7C0DD399437C5406597F727A /* Dependencies */ = {
 			isa = PBXGroup;
 			children = (
-				066BD29BE68B0F984E18B070 /* ArchiveFlowLayout.swift */,
-				4D667185BCE5059D0229114C /* TodoCell.swift */,
-				A4EFE88F3C638250463B4FA2 /* TodoFlowLayout.swift */,
+				3F7C530C657C5D77E6F65BEA /* DependenciesContainer.swift */,
 			);
-			name = Subviews;
-			path = Subviews;
+			name = Dependencies;
+			path = Dependencies;
 			sourceTree = "<group>";
 		};
-		9F57A50F709872C5123F479D /* ListScreen */ = {
+		7CAE0F10FD257B249FC0B3F2 /* TempuraTests */ = {
 			isa = PBXGroup;
 			children = (
-				EAC29BB68511803008671B81 /* ListViewController.swift */,
-				EC2AB3843ABFFEF783B2FA36 /* ListView.swift */,
-				91A745937C1DA6F5EB1D068E /* Subviews */,
-				691B5AAF78D0ABFF0B97FC1D /* ChildViewController.swift */,
-			);
-			name = ListScreen;
-			path = ListScreen;
-			sourceTree = "<group>";
-		};
-		BBC8585E34EF4FAF64D72F67 /* Resources */ = {
-			isa = PBXGroup;
-			children = (
-				CD88C54DB088501AE41771FC /* Media.xcassets */,
-			);
-			name = Resources;
-			path = Resources;
-			sourceTree = "<group>";
-		};
-		CEFD7CA55420B7F03CEE6CD7 = {
-			isa = PBXGroup;
-			children = (
-				4050D36DCED3A30B6B882E9F /* Products */,
-				EB5183ECDE10190DEFB79EE8 /* TempuraTests */,
-				75A9E4B1DE66700042956C8C /* Tempura */,
-				F93EC24FAC18910425BC02BB /* DemoTests */,
-				748DEEF0C285CCA982F8F585 /* Demo */,
-				8904F63DB146ADB80B75F8EB /* Frameworks */,
-				580F5EDE0F698F5AEDA229F6 /* Pods */,
-			);
-			sourceTree = "<group>";
-		};
-		CF28E6D7AC8158BB8D3E469A /* UITests */ = {
-			isa = PBXGroup;
-			children = (
-				A73CEBBED3723AB91E50AD43 /* UITests.swift */,
-				F59068F107DD5A8AE4AF7FC3 /* LocalFileURLProtocol.swift */,
-				FC727A979E70A5B2A5D11384 /* UIView+snapshot.swift */,
-				86701B6C0EDB65EDEB07806B /* ViewTestCase.swift */,
-				8DE0220F6B220A8E272E2D8F /* ViewControllerTestCase.swift */,
-			);
-			name = UITests;
-			path = UITests;
-			sourceTree = "<group>";
-		};
-		D26ED15FB34355CC0353B89C /* Application */ = {
-			isa = PBXGroup;
-			children = (
-				E9DA70412AAC2D7B68E1D8E8 /* AppDelegate.swift */,
-			);
-			name = Application;
-			path = Application;
-			sourceTree = "<group>";
-		};
-		EB5183ECDE10190DEFB79EE8 /* TempuraTests */ = {
-			isa = PBXGroup;
-			children = (
-				CBC2ABC900303DE2866BF967 /* ViewControllerSpec.swift */,
-				87E4C6ABC71FC1664E4FF861 /* ViewControllerContainmentSpec.swift */,
-				05D656105211F5F476174322 /* ViewControllerWithLocalStateSpec.swift */,
+				7A5C33BAFA60225650D6B732 /* ViewControllerSpec.swift */,
+				F6D5BC69D3350D1B9D715C3C /* ViewControllerContainmentSpec.swift */,
+				184B014CD1FFE92F896DFC30 /* ViewControllerWithLocalStateSpec.swift */,
 			);
 			name = TempuraTests;
 			path = TempuraTests;
 			sourceTree = "<group>";
 		};
-		EEFF1DA88C4AB4C00FF5A7BA /* Subviews */ = {
+		8A60C4D58F4FEC199CEEB6C6 /* Demo */ = {
 			isa = PBXGroup;
 			children = (
-				EABFD66BC29C2F8C9454A4FA /* TextView.swift */,
+				8D60BF094FDC6EF8DB471575 /* UI */,
+				F93EA14FC3FA4C61D2D7380E /* Navigation */,
+				7C0DD399437C5406597F727A /* Dependencies */,
+				D51A7391986EEB39473CBBDB /* State */,
+				5AD2AD3801E1145FF2FD2872 /* Utilities */,
+				D7D53C5D07F3B9EF01E37223 /* Actions */,
+				A5C997FDBDFD8F9088B3D165 /* Application */,
+				E4B051AA8A6A186473F9C193 /* Resources */,
+			);
+			name = Demo;
+			path = Demo;
+			sourceTree = "<group>";
+		};
+		8D210A56029AE558547CFC51 /* UITests */ = {
+			isa = PBXGroup;
+			children = (
+				2F2056966CBA35070A5D350F /* UITests.swift */,
+				E46224FFEBC481FA50279FEE /* LocalFileURLProtocol.swift */,
+				CA3EC8FDEE4DC2807E9E72F6 /* UIView+snapshot.swift */,
+				9AC7315440692AACA1241582 /* ViewTestCase.swift */,
+				B9E1399C697BC5EEF942A3CF /* ViewControllerTestCase.swift */,
+			);
+			name = UITests;
+			path = UITests;
+			sourceTree = "<group>";
+		};
+		8D60BF094FDC6EF8DB471575 /* UI */ = {
+			isa = PBXGroup;
+			children = (
+				DADE2610835FB17870F2529B /* ListScreen */,
+				22187D0F5197DABDFDD21723 /* AddItemScreen */,
+			);
+			name = UI;
+			path = UI;
+			sourceTree = "<group>";
+		};
+		94F1688C69043B613C7BE9DE /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				1D173251D097C01031976550 /* Foundation.framework */,
+				5C130AE32D4EDAC409B19A41 /* UIKit.framework */,
+			);
+			name = iOS;
+			sourceTree = "<group>";
+		};
+		A11A7BCA2DC4D9DBFFF1306B /* Subviews */ = {
+			isa = PBXGroup;
+			children = (
+				A53E2964506D66472337355C /* TextView.swift */,
 			);
 			name = Subviews;
 			path = Subviews;
 			sourceTree = "<group>";
 		};
-		F93EC24FAC18910425BC02BB /* DemoTests */ = {
+		A5C997FDBDFD8F9088B3D165 /* Application */ = {
 			isa = PBXGroup;
 			children = (
-				C2F4D5205058D032237FF3E0 /* DemoTests.swift */,
+				995545296A8A7AE7E8D58645 /* AppDelegate.swift */,
+			);
+			name = Application;
+			path = Application;
+			sourceTree = "<group>";
+		};
+		AEFA00A76C63B755867294DC /* DemoTests */ = {
+			isa = PBXGroup;
+			children = (
+				8DC50F0E5AA0F6C70373EBBC /* DemoTests.swift */,
 			);
 			name = DemoTests;
 			path = DemoTests;
 			sourceTree = "<group>";
 		};
+		CDACA981441DBC60BA6B6065 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				CBD200BDEA2EBF67BD1164F3 /* TempuraTests.xctest */,
+				22F42FAD59238FD79B9C8F38 /* Tempura.framework */,
+				C943382F9E5F42B501C4B974 /* TempuraTesting.framework */,
+				03207435C27B3BA015183220 /* DemoTests.xctest */,
+				1DDA36E967230883EF4E8D53 /* Demo.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		CE50A14BB02040C75E6353F3 /* CollectionView */ = {
+			isa = PBXGroup;
+			children = (
+				164B34F6CD3CF5FEEB1FD5B3 /* Source.swift */,
+				5A237D4BC151C98EDE2190FD /* CollectionView.swift */,
+				9D703ADC8E96A5B1810899F7 /* DataSource.swift */,
+				4A0326F9B3D7FAEED676E6B8 /* ConfigurableCell.swift */,
+			);
+			name = CollectionView;
+			path = CollectionView;
+			sourceTree = "<group>";
+		};
+		D51A7391986EEB39473CBBDB /* State */ = {
+			isa = PBXGroup;
+			children = (
+				E202D263AC91E57EF107CE6F /* AppState.swift */,
+				E7392B93FA131402229318FA /* Models.swift */,
+			);
+			name = State;
+			path = State;
+			sourceTree = "<group>";
+		};
+		D7D53C5D07F3B9EF01E37223 /* Actions */ = {
+			isa = PBXGroup;
+			children = (
+				BCA59D1B518AE32DC1182872 /* ItemActions.swift */,
+			);
+			name = Actions;
+			path = Actions;
+			sourceTree = "<group>";
+		};
+		DADE2610835FB17870F2529B /* ListScreen */ = {
+			isa = PBXGroup;
+			children = (
+				907CF40A610C54C52D1E08FA /* ListViewController.swift */,
+				73A14F07C2987E4988F7B67B /* ListView.swift */,
+				435A4657730A540501BB0086 /* Subviews */,
+				DE3D0BE0D35273882E284B4A /* ChildViewController.swift */,
+			);
+			name = ListScreen;
+			path = ListScreen;
+			sourceTree = "<group>";
+		};
+		DD2A773F944A89F1F1496F66 /* Navigation */ = {
+			isa = PBXGroup;
+			children = (
+				93A2E715A24EA2BD61386830 /* UINavigationController+Completion.swift */,
+				94990D7E78EEC74CFB590E9F /* NavigationActions.swift */,
+				5564081DF13E2DCA4A754F66 /* NavigationUtilities.swift */,
+				36226BAB6DE2963229C3C853 /* Routable.swift */,
+				077C700F068523626965D032 /* RootInstaller.swift */,
+				4267731146963574851DAFC7 /* NavigationDSL.swift */,
+				611BBDB76D0812419D552DD7 /* NavigationProvider.swift */,
+				66ED1355D2D21398BF7337F8 /* Navigator.swift */,
+			);
+			name = Navigation;
+			path = Navigation;
+			sourceTree = "<group>";
+		};
+		E27B94DF3BF41203FDDBDA8C /* SupportingFiles */ = {
+			isa = PBXGroup;
+			children = (
+				1972A28C80AD0240B932B09D /* Tempura.h */,
+			);
+			name = SupportingFiles;
+			path = SupportingFiles;
+			sourceTree = "<group>";
+		};
+		E4B051AA8A6A186473F9C193 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				C35DA519D7C3EAA058B502D2 /* Media.xcassets */,
+			);
+			name = Resources;
+			path = Resources;
+			sourceTree = "<group>";
+		};
+		F93EA14FC3FA4C61D2D7380E /* Navigation */ = {
+			isa = PBXGroup;
+			children = (
+				0F1ECA92178B8C12065DCC51 /* AppNavigation.swift */,
+			);
+			name = Navigation;
+			path = Navigation;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
-		5D6E275AE76C3699BC578B33 /* Headers */ = {
+		5C034A754F13AB802ADE4CDF /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BC768E11101864BE218D150F /* Tempura.h in Headers */,
+				BB0F6E1EF56164AD23E9CFA5 /* Tempura.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		E45D2A3CA96FFF201E1CAA62 /* Headers */ = {
+		96C4284C20CFB8A42FE9CA68 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B0F7C0A25316670291BDFA38 /* Tempura.h in Headers */,
+				6902A60816CC51C5C8C4A814 /* Tempura.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		1892DB9BA2060E15764CAD26 /* Demo */ = {
+		36639CBF94BFDF986FB81769 /* DemoTests */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = A64276CEDEB8AABDB06FB788 /* Build configuration list for PBXNativeTarget "Demo" */;
+			buildConfigurationList = 6FEF51128F0F581CF38B12FA /* Build configuration list for PBXNativeTarget "DemoTests" */;
 			buildPhases = (
-				AEBE6ADA5497276B9B56E33E /* [CP] Check Pods Manifest.lock */,
-				36109B4AA647D79EA72BA81D /* Frameworks */,
-				A10189EEF4C0F563310BC6F9 /* Sources */,
-				CA3056CB5B0CAE9405845BD2 /* Resources */,
-				C11208E2B87D4616E5A9E3BF /* Lint */,
-				583EC4D7FF7515D828E8DA8C /* [CP] Embed Pods Frameworks */,
+				05173800868A8E80716BE4D8 /* [CP] Check Pods Manifest.lock */,
+				35518798597B8C933686910D /* Frameworks */,
+				73CA390EFF592ECEC2731A4F /* Sources */,
+				CEA28BC3E5F373BF217D2893 /* Lint */,
+				49EB01901957DE7004485036 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				4BC27CE2D6817A4E9B65C619 /* PBXTargetDependency */,
+				6F20793620D19F2DFC563A8A /* PBXTargetDependency */,
+				63A39CB88DF2A2E058E7FA46 /* PBXTargetDependency */,
 			);
-			name = Demo;
-			productName = Demo;
-			productReference = 3CE9616DD53A600BD4B573C5 /* Demo.app */;
-			productType = "com.apple.product-type.application";
+			name = DemoTests;
+			productName = DemoTests;
+			productReference = 03207435C27B3BA015183220 /* DemoTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
 		};
-		63F9441577436A029C256B73 /* Tempura */ = {
+		47E90BD5AE2CEA07544F18A4 /* TempuraTests */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = F4448B479DB2447BCC913B37 /* Build configuration list for PBXNativeTarget "Tempura" */;
+			buildConfigurationList = D77E89D64C27AF72B337D4BE /* Build configuration list for PBXNativeTarget "TempuraTests" */;
 			buildPhases = (
-				49FBA434F9088C05A67DCBA8 /* [CP] Check Pods Manifest.lock */,
-				E7B960DF32B8F37E244CC2DD /* Sources */,
-				5D6E275AE76C3699BC578B33 /* Headers */,
-				AE7F79DD87640EF434584991 /* Lint */,
-				F8324919E965E45D728A15AA /* Frameworks */,
+				17FE9A6807E345F4A148DC73 /* [CP] Check Pods Manifest.lock */,
+				3565D5C367159A3C3BD55263 /* Frameworks */,
+				909B0B89313C18AADD85A0A4 /* Sources */,
+				0B2757FCAB005948B73A18BA /* Lint */,
+				EC675E027DB6065E28D63185 /* [CP] Embed Pods Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				91AFCB2325525F93D09B4C5A /* PBXTargetDependency */,
+			);
+			name = TempuraTests;
+			productName = TempuraTests;
+			productReference = CBD200BDEA2EBF67BD1164F3 /* TempuraTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		9A7B2C2C4784A31CB213B287 /* Tempura */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 16655949552D1BE42ED4E24A /* Build configuration list for PBXNativeTarget "Tempura" */;
+			buildPhases = (
+				31479FFA9B580EEAF28384A1 /* [CP] Check Pods Manifest.lock */,
+				ECD81D2555899EAB13A3A2BE /* Frameworks */,
+				4DAE426523CB747935E10998 /* Sources */,
+				5C034A754F13AB802ADE4CDF /* Headers */,
+				FA3AE4050FD095E286297945 /* Lint */,
 			);
 			buildRules = (
 			);
@@ -623,18 +643,18 @@
 			);
 			name = Tempura;
 			productName = Tempura;
-			productReference = F8AC45BAB0DC56AA13EBEB62 /* Tempura.framework */;
+			productReference = 22F42FAD59238FD79B9C8F38 /* Tempura.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		938119F7066AAFEC015082C7 /* TempuraTesting */ = {
+		C3B2B96BE82BCDAED4C2C527 /* TempuraTesting */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 15EB5E0F13084D6EB4BD39A3 /* Build configuration list for PBXNativeTarget "TempuraTesting" */;
+			buildConfigurationList = FC36EC5793D081B7C39C5271 /* Build configuration list for PBXNativeTarget "TempuraTesting" */;
 			buildPhases = (
-				2E887E597EB85A367D738EE0 /* [CP] Check Pods Manifest.lock */,
-				E21CBFD2A315B09355D4950D /* Sources */,
-				E45D2A3CA96FFF201E1CAA62 /* Headers */,
-				9E5CC03334EA12E794D5C738 /* Lint */,
-				214970ED9788985D0BEA553A /* Frameworks */,
+				967EB0C6EA578452CCD65B8D /* [CP] Check Pods Manifest.lock */,
+				8478B7BA0BA582B57D5F2951 /* Frameworks */,
+				BAC371E5444F3E2D9EECED52 /* Sources */,
+				96C4284C20CFB8A42FE9CA68 /* Headers */,
+				FDB0FF0E5F423E66D0E66BEE /* Lint */,
 			);
 			buildRules = (
 			);
@@ -642,93 +662,158 @@
 			);
 			name = TempuraTesting;
 			productName = TempuraTesting;
-			productReference = 34E120467BD6EC7E76E20896 /* TempuraTesting.framework */;
+			productReference = C943382F9E5F42B501C4B974 /* TempuraTesting.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		DD0BF01FD4EC19D9D2CE5FD1 /* DemoTests */ = {
+		F133CD648D5FA1083759D479 /* Demo */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 1FB8055BF9E5770E6511C145 /* Build configuration list for PBXNativeTarget "DemoTests" */;
+			buildConfigurationList = 94CB091E5375712A74F1D39E /* Build configuration list for PBXNativeTarget "Demo" */;
 			buildPhases = (
-				91691BDB0E9D43BC90D4ED4C /* [CP] Check Pods Manifest.lock */,
-				5E20147194A6A188203E353B /* Frameworks */,
-				700B358CC4A4C4EA191AFA2A /* Sources */,
-				C57EC039AD78C83383DE26DB /* Lint */,
-				0798B6A49EB100AE8C73CA9D /* [CP] Embed Pods Frameworks */,
+				4F802F3A2016C4CCFB471DD1 /* [CP] Check Pods Manifest.lock */,
+				762686097E1040E223C59852 /* Frameworks */,
+				A0296152AB72555AAC709E11 /* Sources */,
+				4F0F4F60F2C8E24E4D2BDEA8 /* Resources */,
+				F2F737519AC1E7284179F40E /* Lint */,
+				F384E2F226EE23EB5305752E /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				D93E36FF5FF49A8C24A5FF9E /* PBXTargetDependency */,
-				0DA130F1DF93379B5C6106BA /* PBXTargetDependency */,
+				BB43CB9E668D6FA674758EFC /* PBXTargetDependency */,
 			);
-			name = DemoTests;
-			productName = DemoTests;
-			productReference = C236F14F6AA046203BB0750F /* DemoTests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
-		DF8BA7CFDC5D62AED11344B4 /* TempuraTests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = C9BC7BB0B4F68F6843A69405 /* Build configuration list for PBXNativeTarget "TempuraTests" */;
-			buildPhases = (
-				6957E6C74C22A28B698A2603 /* [CP] Check Pods Manifest.lock */,
-				E5F6C7A182607320ADB3E7BC /* Frameworks */,
-				75487B81E05C795BC600E4CF /* Sources */,
-				4903DC8DC865A25172723727 /* Lint */,
-				5555390E33C785FE08554CE2 /* [CP] Embed Pods Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				2710AF317E0B021C857A47C0 /* PBXTargetDependency */,
-			);
-			name = TempuraTests;
-			productName = TempuraTests;
-			productReference = 61E6704CB2184446DCDE6994 /* TempuraTests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
+			name = Demo;
+			productName = Demo;
+			productReference = 1DDA36E967230883EF4E8D53 /* Demo.app */;
+			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
-		D8A0132519FEF6C29B59D75F /* Project object */ = {
+		8EC533182C3CFE067090F556 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1100;
 				LastUpgradeCheck = 1100;
 			};
-			buildConfigurationList = A1513D7397A11AC7AB21F736 /* Build configuration list for PBXProject "Tempura" */;
+			buildConfigurationList = 7792EEA86B6ABF296513F6DA /* Build configuration list for PBXProject "Tempura" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
-			mainGroup = CEFD7CA55420B7F03CEE6CD7;
-			productRefGroup = 4050D36DCED3A30B6B882E9F /* Products */;
+			mainGroup = 584F31C62524439AF2DEBAE9;
+			productRefGroup = CDACA981441DBC60BA6B6065 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				DF8BA7CFDC5D62AED11344B4 /* TempuraTests */,
-				63F9441577436A029C256B73 /* Tempura */,
-				938119F7066AAFEC015082C7 /* TempuraTesting */,
-				DD0BF01FD4EC19D9D2CE5FD1 /* DemoTests */,
-				1892DB9BA2060E15764CAD26 /* Demo */,
+				47E90BD5AE2CEA07544F18A4 /* TempuraTests */,
+				9A7B2C2C4784A31CB213B287 /* Tempura */,
+				C3B2B96BE82BCDAED4C2C527 /* TempuraTesting */,
+				36639CBF94BFDF986FB81769 /* DemoTests */,
+				F133CD648D5FA1083759D479 /* Demo */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		CA3056CB5B0CAE9405845BD2 /* Resources */ = {
+		4F0F4F60F2C8E24E4D2BDEA8 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A916AB90CCCBDBFAEB2044FD /* Media.xcassets in Resources */,
+				62640D5C3BC1265ED855FEEA /* Media.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		0798B6A49EB100AE8C73CA9D /* [CP] Embed Pods Frameworks */ = {
+		05173800868A8E80716BE4D8 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-DemoTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		0B2757FCAB005948B73A18BA /* Lint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = Lint;
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+		17FE9A6807E345F4A148DC73 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-TempuraTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		31479FFA9B580EEAF28384A1 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Tempura-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		49EB01901957DE7004485036 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -754,7 +839,29 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-DemoTests/Pods-DemoTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		2E887E597EB85A367D738EE0 /* [CP] Check Pods Manifest.lock */ = {
+		4F802F3A2016C4CCFB471DD1 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Tempura-Demo-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		967EB0C6EA578452CCD65B8D /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -776,7 +883,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		4903DC8DC865A25172723727 /* Lint */ = {
+		CEA28BC3E5F373BF217D2893 /* Lint */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -794,29 +901,7 @@
 			shellPath = /bin/sh;
 			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
-		49FBA434F9088C05A67DCBA8 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-Tempura-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		5555390E33C785FE08554CE2 /* [CP] Embed Pods Frameworks */ = {
+		EC675E027DB6065E28D63185 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -840,7 +925,25 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-TempuraTests/Pods-TempuraTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		583EC4D7FF7515D828E8DA8C /* [CP] Embed Pods Frameworks */ = {
+		F2F737519AC1E7284179F40E /* Lint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = Lint;
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+		F384E2F226EE23EB5305752E /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -864,51 +967,7 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Tempura-Demo/Pods-Tempura-Demo-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		6957E6C74C22A28B698A2603 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-TempuraTests-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		91691BDB0E9D43BC90D4ED4C /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-DemoTests-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		9E5CC03334EA12E794D5C738 /* Lint */ = {
+		FA3AE4050FD095E286297945 /* Lint */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -926,65 +985,7 @@
 			shellPath = /bin/sh;
 			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
-		AE7F79DD87640EF434584991 /* Lint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = Lint;
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
-		};
-		AEBE6ADA5497276B9B56E33E /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-Tempura-Demo-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		C11208E2B87D4616E5A9E3BF /* Lint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = Lint;
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
-		};
-		C57EC039AD78C83383DE26DB /* Lint */ = {
+		FDB0FF0E5F423E66D0E66BEE /* Lint */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1005,158 +1006,155 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		700B358CC4A4C4EA191AFA2A /* Sources */ = {
+		4DAE426523CB747935E10998 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				85C2305339E3864DEB0BDF5E /* DemoTests.swift in Sources */,
+				6752CCE8453D2481D2D7F1B0 /* ViewController.swift in Sources */,
+				9B839B60261ABB64C993F98A /* View.swift in Sources */,
+				ACAF6CF7BB336F6F4C3C24D1 /* ViewModelWithState.swift in Sources */,
+				CDB0B03F11357A63FC30F8B0 /* ModellableView.swift in Sources */,
+				ED9DDF99494335BAFC5AE3F3 /* ViewModelWithLocalState.swift in Sources */,
+				2C91DF1DDBF43118370E7843 /* LocalState.swift in Sources */,
+				A93F6A743B0D6A2EE43FE3A5 /* ViewModel.swift in Sources */,
+				5FD41A4BFFF656718C3FFDAC /* ViewControllerModellableView.swift in Sources */,
+				FA72ED0C5378180E05494A41 /* ViewControllerWithLocalState.swift in Sources */,
+				7515EBCDA7D68B3D7D2A199A /* ViewController+Containment.swift in Sources */,
+				366DFD7D1FF452047A8466BF /* UINavigationController+Completion.swift in Sources */,
+				CE7E561A52732025016E9AE6 /* NavigationActions.swift in Sources */,
+				1F2B6F84C8C534759AC1695A /* NavigationUtilities.swift in Sources */,
+				3C64D84F52EB4E72AF4E819A /* Routable.swift in Sources */,
+				6442760EEE874C7B086CABDB /* RootInstaller.swift in Sources */,
+				15693720E48E2CB0D466100C /* NavigationDSL.swift in Sources */,
+				16F49F1816FCF15CD5FEB646 /* NavigationProvider.swift in Sources */,
+				7050586D8609EF254C8CED85 /* Navigator.swift in Sources */,
+				96F280DDF3B0F102319ABD06 /* MainThread.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		75487B81E05C795BC600E4CF /* Sources */ = {
+		73CA390EFF592ECEC2731A4F /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2B2F433F3C1381BE8895D70C /* ViewControllerSpec.swift in Sources */,
-				4AD473966E75953A560ACFB8 /* ViewControllerContainmentSpec.swift in Sources */,
-				F3362759DC492B650AF41E97 /* ViewControllerWithLocalStateSpec.swift in Sources */,
+				BFD48F41F7B6860E3D3AFEF1 /* DemoTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		A10189EEF4C0F563310BC6F9 /* Sources */ = {
+		909B0B89313C18AADD85A0A4 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2A59B2588D5039E9742C0FEE /* ListViewController.swift in Sources */,
-				C32A373AE5DD74F4E7A906F2 /* ListView.swift in Sources */,
-				16D0F5B72CFC3A8DB7C1ED34 /* ArchiveFlowLayout.swift in Sources */,
-				05E2534CB0949F57C289B17B /* TodoCell.swift in Sources */,
-				653EE0027CA643E4DF1441DB /* TodoFlowLayout.swift in Sources */,
-				A30654AB82587AC95D2106E3 /* ChildViewController.swift in Sources */,
-				BA447B21D436A5916D32E922 /* TextView.swift in Sources */,
-				DC97415E496CCF4540BE62B5 /* AddItemView.swift in Sources */,
-				754FDF4F8444F74AE5469556 /* AddItemViewController.swift in Sources */,
-				DC787376F7CC41C5A8239DC6 /* AppNavigation.swift in Sources */,
-				583E3DADF9F8D7C140844D21 /* DependenciesContainer.swift in Sources */,
-				401C27D9182B5710B17217F0 /* AppState.swift in Sources */,
-				164BFE537307B1DE296C1BD9 /* Models.swift in Sources */,
-				4173BF2B98ABDB7A4F9F52DD /* UIControl+TargetActionable.swift in Sources */,
-				BD903C3385484D5964202F9C /* String+Random.swift in Sources */,
-				7811FF4D9522E68441422C07 /* Source.swift in Sources */,
-				331E6014ECDC140319AE0A33 /* CollectionView.swift in Sources */,
-				6D56B8C0BC4BD89BAB0C9C1F /* DataSource.swift in Sources */,
-				EDA9631F88684BFE6F175D9E /* ConfigurableCell.swift in Sources */,
-				DA7699F1C284567A72EA6DF3 /* CGRect+Utils.swift in Sources */,
-				3DAC790CF1EA187168CC369C /* UIView+Blink.swift in Sources */,
-				CA06A90213FE789A07C5AEA6 /* String+Height.swift in Sources */,
-				698DFC2C2567B939F0FCD3A3 /* ItemActions.swift in Sources */,
-				B9A9C7EE65200C11A3545A43 /* AppDelegate.swift in Sources */,
+				276D9911D025FA454429031F /* ViewControllerSpec.swift in Sources */,
+				4155E662A6311E2174E2D6B2 /* ViewControllerContainmentSpec.swift in Sources */,
+				374049D0F43461E632DA1521 /* ViewControllerWithLocalStateSpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		E21CBFD2A315B09355D4950D /* Sources */ = {
+		A0296152AB72555AAC709E11 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8B9378BDE132B44BCCCA9B45 /* UITests.swift in Sources */,
-				F35BBF87B66743752612C678 /* LocalFileURLProtocol.swift in Sources */,
-				8AEB85629A437B4D01DD21D6 /* UIView+snapshot.swift in Sources */,
-				17437108D9C0094AF2D665F3 /* ViewTestCase.swift in Sources */,
-				D1BCEA441DB3FCDA12159BD0 /* ViewControllerTestCase.swift in Sources */,
+				F1517BD59DCF843518DBC5D3 /* ListViewController.swift in Sources */,
+				D4E73377102DB96BB9833A18 /* ListView.swift in Sources */,
+				A3566DEA66C3D53271E8F003 /* ArchiveFlowLayout.swift in Sources */,
+				A520426AD6FC3E6FCD494B5F /* TodoCell.swift in Sources */,
+				173031089F26CC74607BD3BF /* TodoFlowLayout.swift in Sources */,
+				8DA3B85E6E17DE0D33844C26 /* ChildViewController.swift in Sources */,
+				A9618DC73EC28D4EDC359FD9 /* TextView.swift in Sources */,
+				ADED57C54A077E3F0072BB5E /* AddItemView.swift in Sources */,
+				6D769915D9FD627582137397 /* AddItemViewController.swift in Sources */,
+				78907D2EA385EDCBBFB66AC3 /* AppNavigation.swift in Sources */,
+				5B6CD95C28339C832D3BBE95 /* DependenciesContainer.swift in Sources */,
+				0B40F885055AF0ED9E7C1F05 /* AppState.swift in Sources */,
+				956ECE61861A11B2D5A3CE6D /* Models.swift in Sources */,
+				8B8A3C7D229764490703D96F /* UIControl+TargetActionable.swift in Sources */,
+				C337643FD022F28ED5FB9ED4 /* String+Random.swift in Sources */,
+				24CF6B734B00054961F90E32 /* Source.swift in Sources */,
+				1D8FB5CA9F23A630FE4730C5 /* CollectionView.swift in Sources */,
+				3F6D32AC5532E7AEC948A542 /* DataSource.swift in Sources */,
+				AC2114E0CD7993C96F55AA82 /* ConfigurableCell.swift in Sources */,
+				D72356D6A3B6058127B8C734 /* CGRect+Utils.swift in Sources */,
+				EB16DE1D7508E101CA6717D2 /* UIView+Blink.swift in Sources */,
+				85D0FEE49166EA8743AE82C1 /* String+Height.swift in Sources */,
+				B7270653DE261278782C65D6 /* ItemActions.swift in Sources */,
+				2D9235DD879ACBB89F363AF6 /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		E7B960DF32B8F37E244CC2DD /* Sources */ = {
+		BAC371E5444F3E2D9EECED52 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				13925A6071FDB72B0F81753A /* ViewController.swift in Sources */,
-				AA2679831D713F6459355C5F /* View.swift in Sources */,
-				6BB22A800B8303D7FD04219F /* ViewModelWithState.swift in Sources */,
-				5807334E7EE8D7882E3C2204 /* ModellableView.swift in Sources */,
-				381645D475DD642774EE1FB6 /* ViewModelWithLocalState.swift in Sources */,
-				67FE082E1FCE8D9B2B93692D /* LocalState.swift in Sources */,
-				4CABCB025B0BF586FCACFEE5 /* ViewModel.swift in Sources */,
-				A3246A89828660487607D4AE /* ViewControllerModellableView.swift in Sources */,
-				7B9AA70D1D1BA816A91937C8 /* ViewControllerWithLocalState.swift in Sources */,
-				791DDFED0CBF678D2C973B84 /* ViewController+Containment.swift in Sources */,
-				CD30A34C9F58414F7B71CB10 /* UINavigationController+Completion.swift in Sources */,
-				ACF0E5024453640C0EEEA719 /* NavigationActions.swift in Sources */,
-				1A20A82D89E916C8EC185BE1 /* NavigationUtilities.swift in Sources */,
-				1FBF488F33EC00FCB88C9A77 /* Routable.swift in Sources */,
-				FD70636F9BBF8DD4EDF75849 /* RootInstaller.swift in Sources */,
-				FEB890D178B837BA2DE4AD10 /* NavigationDSL.swift in Sources */,
-				A6A30913DB413CB27F51DA60 /* NavigationProvider.swift in Sources */,
-				15B37D299F533123CA928E89 /* Navigator.swift in Sources */,
-				96C90C5CB738DBEBACD186FF /* MainThread.swift in Sources */,
+				F490CAA9033845F307B1E588 /* UITests.swift in Sources */,
+				204DA40CDE139295A1D7FAEF /* LocalFileURLProtocol.swift in Sources */,
+				003A74B417A6AEA0C6662521 /* UIView+snapshot.swift in Sources */,
+				4A19838FCCEEB877D0044609 /* ViewTestCase.swift in Sources */,
+				2EDE730F3776F9AA8930B836 /* ViewControllerTestCase.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		0DA130F1DF93379B5C6106BA /* PBXTargetDependency */ = {
+		63A39CB88DF2A2E058E7FA46 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = TempuraTesting;
-			target = 938119F7066AAFEC015082C7 /* TempuraTesting */;
-			targetProxy = 949305310339F87701FC8E80 /* PBXContainerItemProxy */;
+			target = C3B2B96BE82BCDAED4C2C527 /* TempuraTesting */;
+			targetProxy = AA4FDDB9F87D0DB5C9495E3F /* PBXContainerItemProxy */;
 		};
-		2710AF317E0B021C857A47C0 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Tempura;
-			target = 63F9441577436A029C256B73 /* Tempura */;
-			targetProxy = A8C9EE0EFC1625F8C25984C9 /* PBXContainerItemProxy */;
-		};
-		4BC27CE2D6817A4E9B65C619 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Tempura;
-			target = 63F9441577436A029C256B73 /* Tempura */;
-			targetProxy = C65C44281DE4235F6BF8172E /* PBXContainerItemProxy */;
-		};
-		D93E36FF5FF49A8C24A5FF9E /* PBXTargetDependency */ = {
+		6F20793620D19F2DFC563A8A /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = Demo;
-			target = 1892DB9BA2060E15764CAD26 /* Demo */;
-			targetProxy = 89F207ECC961FDCBD91606F8 /* PBXContainerItemProxy */;
+			target = F133CD648D5FA1083759D479 /* Demo */;
+			targetProxy = 3E94D9AB36086D71D1FD3806 /* PBXContainerItemProxy */;
+		};
+		91AFCB2325525F93D09B4C5A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Tempura;
+			target = 9A7B2C2C4784A31CB213B287 /* Tempura */;
+			targetProxy = 0079F4AE23BE7BCA0FBB1B39 /* PBXContainerItemProxy */;
+		};
+		BB43CB9E668D6FA674758EFC /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Tempura;
+			target = 9A7B2C2C4784A31CB213B287 /* Tempura */;
+			targetProxy = 9E17CB8A8DE47C8A983B66F4 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		02F7A6D2360109172227129B /* Release */ = {
+		008C44B27F245978DC43D73B /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = EED1692C3B2CB9E16B5C8E3A /* Pods-Tempura-Demo.release.xcconfig */;
+			baseConfigurationReference = 569E390CCB8B0146A15D1AEB /* Pods-TempuraTesting.debug.xcconfig */;
 			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				INFOPLIST_FILE = Demo/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = dk.bendingspoons.AppStation;
-				PRODUCT_NAME = Demo;
-				SDKROOT = iphoneos;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
-			};
-			name = Release;
-		};
-		0B9EFD43B50A9D88E88F4F32 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5C1C6325FC531AA4683C33DC /* Pods-TempuraTests.debug.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				INFOPLIST_FILE = TempuraTests/Info.plist;
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				INFOPLIST_FILE = Tempura/SupportingFiles/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = TempuraTesting;
 				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
 			};
 			name = Debug;
 		};
-		12E9ACB79A2BADB223B710E6 /* Debug */ = {
+		2CED711E53410BB5F0BD13C2 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 224F1C627264EA1E2C97572C /* Pods-Tempura-Demo.debug.xcconfig */;
+			baseConfigurationReference = 3E85CCD29540E3DEE2DA87F0 /* Pods-Tempura-Demo.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -1172,25 +1170,38 @@
 			};
 			name = Debug;
 		};
-		20E7ED66AD3EEB7DE7A47606 /* Release */ = {
+		5AECE5FB29DD4FEEA4F08532 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 967CEE8572EC809D3CCEBBD4 /* Pods-DemoTests.release.xcconfig */;
+			baseConfigurationReference = 1072A73394C9DE763373F81E /* Pods-Tempura.debug.xcconfig */;
 			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				INFOPLIST_FILE = DemoTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				INFOPLIST_FILE = Tempura/SupportingFiles/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = Tempura;
 				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Demo.app/Demo";
-				VALIDATE_PRODUCT = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
 			};
-			name = Release;
+			name = Debug;
 		};
-		36D65D65147C89F8F833A9AC /* Debug */ = {
+		7A6C85C7440240ED5F7BA843 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B8AA42C6C293381338E9D420 /* Pods-DemoTests.debug.xcconfig */;
+			baseConfigurationReference = C8EA6B9D00FA578ACCF03D70 /* Pods-DemoTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -1204,7 +1215,7 @@
 			};
 			name = Debug;
 		};
-		3B05735F62DAEEA019AA5797 /* Debug */ = {
+		7F367232544C854E44B1231B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -1264,108 +1275,55 @@
 			};
 			name = Debug;
 		};
-		41133A241DEA9DB0C83E2170 /* Release */ = {
+		8F5E62497F4364B8AEA3E14B /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = E4EF07632466F97B507ED75A /* Pods-TempuraTests.release.xcconfig */;
+			baseConfigurationReference = F29DBB122D76B66BE9B82FEF /* Pods-DemoTests.release.xcconfig */;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				INFOPLIST_FILE = DemoTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Demo.app/Demo";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		924AA5D39C0F6C387BEC85BB /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 5AFC07783E89FF67C96D2EB4 /* Pods-Tempura-Demo.release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				INFOPLIST_FILE = Demo/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = dk.bendingspoons.AppStation;
+				PRODUCT_NAME = Demo;
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		948A6EB6C8431407DDD2DEF2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = F70BA8019F66F30D9FFAB9F0 /* Pods-TempuraTests.debug.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				INFOPLIST_FILE = TempuraTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				SDKROOT = iphoneos;
-				SWIFT_VERSION = 5.0;
-				VALIDATE_PRODUCT = YES;
-			};
-			name = Release;
-		};
-		71F3F7D658A005A0DCAB4AFA /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 63B570D57882BFAD423B25C7 /* Pods-Tempura.release.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				INFOPLIST_FILE = Tempura/SupportingFiles/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_NAME = Tempura;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		8198D4917CC9BCB63C9EFCB8 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8BFB631A233B1C211DA7E781 /* Pods-TempuraTesting.debug.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				INFOPLIST_FILE = Tempura/SupportingFiles/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_NAME = TempuraTesting;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
 			};
 			name = Debug;
 		};
-		A54CFCDA4BE606A456DE9FB8 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 17E667F0637D2D30AEDEC508 /* Pods-Tempura.debug.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				INFOPLIST_FILE = Tempura/SupportingFiles/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_NAME = Tempura;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		A74609258BA54E2EA1432ADE /* Release */ = {
+		A57AC283733D5F96554CD4B9 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -1418,9 +1376,23 @@
 			};
 			name = Release;
 		};
-		C69EB7CD7938905550834E63 /* Release */ = {
+		B92DD146D03A6AE8D7668425 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8FA45BAC76F4311D4BFB27B3 /* Pods-TempuraTesting.release.xcconfig */;
+			baseConfigurationReference = 7F8048FD19E805306CFC1017 /* Pods-TempuraTests.release.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				INFOPLIST_FILE = TempuraTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		D1390F0926C2ABD10292987B /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = F86D79A5717CA3800CF3EAC9 /* Pods-TempuraTesting.release.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				CURRENT_PROJECT_VERSION = 1;
@@ -1447,64 +1419,93 @@
 			};
 			name = Release;
 		};
+		E7517035A1221FD225A628A8 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 0D79233B0CEED31350194F1C /* Pods-Tempura.release.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				INFOPLIST_FILE = Tempura/SupportingFiles/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = Tempura;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		15EB5E0F13084D6EB4BD39A3 /* Build configuration list for PBXNativeTarget "TempuraTesting" */ = {
+		16655949552D1BE42ED4E24A /* Build configuration list for PBXNativeTarget "Tempura" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				8198D4917CC9BCB63C9EFCB8 /* Debug */,
-				C69EB7CD7938905550834E63 /* Release */,
+				5AECE5FB29DD4FEEA4F08532 /* Debug */,
+				E7517035A1221FD225A628A8 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		1FB8055BF9E5770E6511C145 /* Build configuration list for PBXNativeTarget "DemoTests" */ = {
+		6FEF51128F0F581CF38B12FA /* Build configuration list for PBXNativeTarget "DemoTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				36D65D65147C89F8F833A9AC /* Debug */,
-				20E7ED66AD3EEB7DE7A47606 /* Release */,
+				7A6C85C7440240ED5F7BA843 /* Debug */,
+				8F5E62497F4364B8AEA3E14B /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		A1513D7397A11AC7AB21F736 /* Build configuration list for PBXProject "Tempura" */ = {
+		7792EEA86B6ABF296513F6DA /* Build configuration list for PBXProject "Tempura" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				3B05735F62DAEEA019AA5797 /* Debug */,
-				A74609258BA54E2EA1432ADE /* Release */,
+				7F367232544C854E44B1231B /* Debug */,
+				A57AC283733D5F96554CD4B9 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		A64276CEDEB8AABDB06FB788 /* Build configuration list for PBXNativeTarget "Demo" */ = {
+		94CB091E5375712A74F1D39E /* Build configuration list for PBXNativeTarget "Demo" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				12E9ACB79A2BADB223B710E6 /* Debug */,
-				02F7A6D2360109172227129B /* Release */,
+				2CED711E53410BB5F0BD13C2 /* Debug */,
+				924AA5D39C0F6C387BEC85BB /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		C9BC7BB0B4F68F6843A69405 /* Build configuration list for PBXNativeTarget "TempuraTests" */ = {
+		D77E89D64C27AF72B337D4BE /* Build configuration list for PBXNativeTarget "TempuraTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				0B9EFD43B50A9D88E88F4F32 /* Debug */,
-				41133A241DEA9DB0C83E2170 /* Release */,
+				948A6EB6C8431407DDD2DEF2 /* Debug */,
+				B92DD146D03A6AE8D7668425 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		F4448B479DB2447BCC913B37 /* Build configuration list for PBXNativeTarget "Tempura" */ = {
+		FC36EC5793D081B7C39C5271 /* Build configuration list for PBXNativeTarget "TempuraTesting" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				A54CFCDA4BE606A456DE9FB8 /* Debug */,
-				71F3F7D658A005A0DCAB4AFA /* Release */,
+				008C44B27F245978DC43D73B /* Debug */,
+				D1390F0926C2ABD10292987B /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};
-	rootObject = D8A0132519FEF6C29B59D75F /* Project object */;
+	rootObject = 8EC533182C3CFE067090F556 /* Project object */;
 }

--- a/Tempura.xcodeproj/project.pbxproj
+++ b/Tempura.xcodeproj/project.pbxproj
@@ -259,7 +259,6 @@
 				19802DF62C242B540F6D08B0 /* Subviews */,
 				40068B61E8736ECDCF8AC956 /* ChildViewController.swift */,
 			);
-			name = ListScreen;
 			path = ListScreen;
 			sourceTree = "<group>";
 		};
@@ -270,7 +269,6 @@
 				2249E6C7E0ACC377D139C66C /* TodoCell.swift */,
 				832B7292834EF377971CFD18 /* TodoFlowLayout.swift */,
 			);
-			name = Subviews;
 			path = Subviews;
 			sourceTree = "<group>";
 		};
@@ -281,7 +279,6 @@
 				D896F8845D203FA13DA578FA /* ViewControllerContainmentSpec.swift */,
 				0F8FF0677F29BFC2D025974C /* ViewControllerWithLocalStateSpec.swift */,
 			);
-			name = TempuraTests;
 			path = TempuraTests;
 			sourceTree = "<group>";
 		};
@@ -307,7 +304,6 @@
 				E12738D9235E9889730AD937 /* ViewTestCase.swift */,
 				C0ED2D46724416E9CF59E5A0 /* ViewControllerTestCase.swift */,
 			);
-			name = UITests;
 			path = UITests;
 			sourceTree = "<group>";
 		};
@@ -316,7 +312,6 @@
 			children = (
 				C63EC6033DFD1EEE440CF3D1 /* TextView.swift */,
 			);
-			name = Subviews;
 			path = Subviews;
 			sourceTree = "<group>";
 		};
@@ -325,7 +320,6 @@
 			children = (
 				8C08F1501913CAE489CD32FA /* Media.xcassets */,
 			);
-			name = Resources;
 			path = Resources;
 			sourceTree = "<group>";
 		};
@@ -334,7 +328,6 @@
 			children = (
 				DBBC705291F6071B88EFCDF6 /* MainThread.swift */,
 			);
-			name = Utilities;
 			path = Utilities;
 			sourceTree = "<group>";
 		};
@@ -343,7 +336,6 @@
 			children = (
 				E07FF0D078953E0BD860BC0F /* AppDelegate.swift */,
 			);
-			name = Application;
 			path = Application;
 			sourceTree = "<group>";
 		};
@@ -352,7 +344,6 @@
 			children = (
 				8E84EAA3084551A186FC9FCE /* Tempura.h */,
 			);
-			name = SupportingFiles;
 			path = SupportingFiles;
 			sourceTree = "<group>";
 		};
@@ -361,7 +352,6 @@
 			children = (
 				A0C302DCA2D0F8ABCDDA2A4A /* DependenciesContainer.swift */,
 			);
-			name = Dependencies;
 			path = Dependencies;
 			sourceTree = "<group>";
 		};
@@ -377,7 +367,6 @@
 				6E0AFC243F4CF887049FC725 /* NavigationProvider.swift */,
 				A6553F3749245E6A77B1A2CE /* Navigator.swift */,
 			);
-			name = Navigation;
 			path = Navigation;
 			sourceTree = "<group>";
 		};
@@ -388,7 +377,6 @@
 				99C2A6826D6D5702CE9425AF /* AddItemView.swift */,
 				11C48B39DA231240985F7B20 /* AddItemViewController.swift */,
 			);
-			name = AddItemScreen;
 			path = AddItemScreen;
 			sourceTree = "<group>";
 		};
@@ -398,7 +386,6 @@
 				0F23238972CB06D60209082C /* AppState.swift */,
 				4E07BCD0045E2CA10541C7BD /* Models.swift */,
 			);
-			name = State;
 			path = State;
 			sourceTree = "<group>";
 		};
@@ -408,7 +395,6 @@
 				113B415BBA6E6210F21036F6 /* ListScreen */,
 				8D34FDA05B0B22F8627E7F5E /* AddItemScreen */,
 			);
-			name = UI;
 			path = UI;
 			sourceTree = "<group>";
 		};
@@ -417,7 +403,6 @@
 			children = (
 				69C6CB90C6EE139CCF5B838D /* ItemActions.swift */,
 			);
-			name = Actions;
 			path = Actions;
 			sourceTree = "<group>";
 		};
@@ -439,7 +424,6 @@
 			children = (
 				C05310487807F0E76D63BE7A /* DemoTests.swift */,
 			);
-			name = DemoTests;
 			path = DemoTests;
 			sourceTree = "<group>";
 		};
@@ -451,7 +435,6 @@
 				08884FD53F3851A6A11D4534 /* DataSource.swift */,
 				CEA32A7BB7A56ABE9219DEA3 /* ConfigurableCell.swift */,
 			);
-			name = CollectionView;
 			path = CollectionView;
 			sourceTree = "<group>";
 		};
@@ -464,7 +447,6 @@
 				35D0B1D10DE42F7C00A85ACE /* UITests */,
 				6EB95B8BFD660EC4F86BFE09 /* SupportingFiles */,
 			);
-			name = Tempura;
 			path = Tempura;
 			sourceTree = "<group>";
 		};
@@ -482,7 +464,6 @@
 				2016522A4E514816A0AFF7CF /* ViewControllerWithLocalState.swift */,
 				CA1C2C60CA2509612B2132F2 /* ViewController+Containment.swift */,
 			);
-			name = Core;
 			path = Core;
 			sourceTree = "<group>";
 		};
@@ -500,7 +481,6 @@
 				C9DE409834C1C87B37A02470 /* Pods-TempuraTests.debug.xcconfig */,
 				FDB93D95E96253641C5A462A /* Pods-TempuraTests.release.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -516,7 +496,6 @@
 				61B7211393A06C52ABA4C0B2 /* Application */,
 				5B86F61F4F9C174D861EEB5F /* Resources */,
 			);
-			name = Demo;
 			path = Demo;
 			sourceTree = "<group>";
 		};
@@ -525,7 +504,6 @@
 			children = (
 				42F8C684A37536E6B3B74F09 /* AppNavigation.swift */,
 			);
-			name = Navigation;
 			path = Navigation;
 			sourceTree = "<group>";
 		};
@@ -560,7 +538,6 @@
 				CC2D9839C2FEC766B0F68351 /* UIView+Blink.swift */,
 				8AFBEDB06D415C1374C0158C /* String+Height.swift */,
 			);
-			name = Utilities;
 			path = Utilities;
 			sourceTree = "<group>";
 		};
@@ -694,6 +671,14 @@
 			attributes = {
 				LastSwiftUpdateCheck = 1100;
 				LastUpgradeCheck = 1100;
+				TargetAttributes = {
+					2DBFEB5C4518FCDC7132F05C = {
+						DevelopmentTeam = 94V2323VUL;
+					};
+					ABEAE6541ACDCBEDBB6C3020 = {
+						DevelopmentTeam = 94V2323VUL;
+					};
+				};
 			};
 			buildConfigurationList = 2C8CE42AC5345349D09BDA0A /* Build configuration list for PBXProject "Tempura" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -1218,6 +1203,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				DEVELOPMENT_TEAM = 94V2323VUL;
 				INFOPLIST_FILE = DemoTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -1263,6 +1249,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				DEVELOPMENT_TEAM = 94V2323VUL;
 				INFOPLIST_FILE = Demo/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -1324,6 +1311,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				DEVELOPMENT_TEAM = 94V2323VUL;
 				INFOPLIST_FILE = Demo/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -1397,8 +1385,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
@@ -1438,6 +1425,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				DEVELOPMENT_TEAM = 94V2323VUL;
 				INFOPLIST_FILE = DemoTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";

--- a/Tempura.xcodeproj/xcshareddata/xcschemes/Demo.xcscheme
+++ b/Tempura.xcodeproj/xcshareddata/xcschemes/Demo.xcscheme
@@ -14,7 +14,7 @@
             buildForArchiving = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "1892DB9BA2060E15764CAD26"
+               BlueprintIdentifier = "F133CD648D5FA1083759D479"
                BuildableName = "Demo.app"
                BlueprintName = "Demo"
                ReferencedContainer = "container:Tempura.xcodeproj">
@@ -32,7 +32,7 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "1892DB9BA2060E15764CAD26"
+            BlueprintIdentifier = "F133CD648D5FA1083759D479"
             BuildableName = "Demo.app"
             BlueprintName = "Demo"
             ReferencedContainer = "container:Tempura.xcodeproj">
@@ -43,7 +43,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "DD0BF01FD4EC19D9D2CE5FD1"
+               BlueprintIdentifier = "36639CBF94BFDF986FB81769"
                BuildableName = "DemoTests.xctest"
                BlueprintName = "DemoTests"
                ReferencedContainer = "container:Tempura.xcodeproj">
@@ -67,7 +67,7 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "1892DB9BA2060E15764CAD26"
+            BlueprintIdentifier = "F133CD648D5FA1083759D479"
             BuildableName = "Demo.app"
             BlueprintName = "Demo"
             ReferencedContainer = "container:Tempura.xcodeproj">
@@ -83,7 +83,7 @@
       <BuildableProductRunnable>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "1892DB9BA2060E15764CAD26"
+            BlueprintIdentifier = "F133CD648D5FA1083759D479"
             BuildableName = "Demo.app"
             BlueprintName = "Demo"
             ReferencedContainer = "container:Tempura.xcodeproj">

--- a/Tempura.xcodeproj/xcshareddata/xcschemes/Demo.xcscheme
+++ b/Tempura.xcodeproj/xcshareddata/xcschemes/Demo.xcscheme
@@ -14,7 +14,7 @@
             buildForArchiving = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "F133CD648D5FA1083759D479"
+               BlueprintIdentifier = "2DBFEB5C4518FCDC7132F05C"
                BuildableName = "Demo.app"
                BlueprintName = "Demo"
                ReferencedContainer = "container:Tempura.xcodeproj">
@@ -32,7 +32,7 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "F133CD648D5FA1083759D479"
+            BlueprintIdentifier = "2DBFEB5C4518FCDC7132F05C"
             BuildableName = "Demo.app"
             BlueprintName = "Demo"
             ReferencedContainer = "container:Tempura.xcodeproj">
@@ -43,7 +43,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "36639CBF94BFDF986FB81769"
+               BlueprintIdentifier = "ABEAE6541ACDCBEDBB6C3020"
                BuildableName = "DemoTests.xctest"
                BlueprintName = "DemoTests"
                ReferencedContainer = "container:Tempura.xcodeproj">
@@ -67,7 +67,7 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "F133CD648D5FA1083759D479"
+            BlueprintIdentifier = "2DBFEB5C4518FCDC7132F05C"
             BuildableName = "Demo.app"
             BlueprintName = "Demo"
             ReferencedContainer = "container:Tempura.xcodeproj">
@@ -83,7 +83,7 @@
       <BuildableProductRunnable>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "F133CD648D5FA1083759D479"
+            BlueprintIdentifier = "2DBFEB5C4518FCDC7132F05C"
             BuildableName = "Demo.app"
             BlueprintName = "Demo"
             ReferencedContainer = "container:Tempura.xcodeproj">

--- a/Tempura.xcodeproj/xcshareddata/xcschemes/Tempura.xcscheme
+++ b/Tempura.xcodeproj/xcshareddata/xcschemes/Tempura.xcscheme
@@ -14,7 +14,7 @@
             buildForArchiving = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "63F9441577436A029C256B73"
+               BlueprintIdentifier = "9A7B2C2C4784A31CB213B287"
                BuildableName = "Tempura.framework"
                BlueprintName = "Tempura"
                ReferencedContainer = "container:Tempura.xcodeproj">
@@ -34,7 +34,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "DF8BA7CFDC5D62AED11344B4"
+               BlueprintIdentifier = "47E90BD5AE2CEA07544F18A4"
                BuildableName = "TempuraTests.xctest"
                BlueprintName = "TempuraTests"
                ReferencedContainer = "container:Tempura.xcodeproj">

--- a/Tempura.xcodeproj/xcshareddata/xcschemes/Tempura.xcscheme
+++ b/Tempura.xcodeproj/xcshareddata/xcschemes/Tempura.xcscheme
@@ -14,7 +14,7 @@
             buildForArchiving = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "9A7B2C2C4784A31CB213B287"
+               BlueprintIdentifier = "8B7292CC2417BBB996CFC789"
                BuildableName = "Tempura.framework"
                BlueprintName = "Tempura"
                ReferencedContainer = "container:Tempura.xcodeproj">
@@ -34,7 +34,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "47E90BD5AE2CEA07544F18A4"
+               BlueprintIdentifier = "FD68948F1596E6F67312F485"
                BuildableName = "TempuraTests.xctest"
                BlueprintName = "TempuraTests"
                ReferencedContainer = "container:Tempura.xcodeproj">

--- a/Tempura.xcodeproj/xcshareddata/xcschemes/TempuraTesting.xcscheme
+++ b/Tempura.xcodeproj/xcshareddata/xcschemes/TempuraTesting.xcscheme
@@ -14,7 +14,7 @@
             buildForArchiving = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "938119F7066AAFEC015082C7"
+               BlueprintIdentifier = "C3B2B96BE82BCDAED4C2C527"
                BuildableName = "TempuraTesting.framework"
                BlueprintName = "TempuraTesting"
                ReferencedContainer = "container:Tempura.xcodeproj">

--- a/Tempura.xcodeproj/xcshareddata/xcschemes/TempuraTesting.xcscheme
+++ b/Tempura.xcodeproj/xcshareddata/xcschemes/TempuraTesting.xcscheme
@@ -14,7 +14,7 @@
             buildForArchiving = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "C3B2B96BE82BCDAED4C2C527"
+               BlueprintIdentifier = "E83AC9A1F08F0A742FE602FF"
                BuildableName = "TempuraTesting.framework"
                BlueprintName = "TempuraTesting"
                ReferencedContainer = "container:Tempura.xcodeproj">

--- a/Tempura/UITests/UITests.swift
+++ b/Tempura/UITests/UITests.swift
@@ -32,12 +32,14 @@ public enum UITests {
   
   
   public struct VCScreenSnapshot<VC: AnyViewController> {
+    let vc: () -> VC
     let container: Container
-    let testCases: [String: VC]
+    let testCases: [String]
     let hooks: [Hook: HookClosure<VC.V>]
     let size: CGSize
     
-    init(container: Container, testCases: [String: VC], hooks: [Hook: HookClosure<VC.V>], size: CGSize) {
+    init(vc: @autoclosure @escaping () -> VC, container: Container, testCases: [String], hooks: [Hook: HookClosure<VC.V>], size: CGSize) {
+      self.vc = vc
       self.container = container
       self.testCases = testCases
       self.hooks = hooks
@@ -45,9 +47,8 @@ public enum UITests {
     }
     
     public var renderingViewControllers: [String: (container: UIViewController, contained: VC)] {
-      return self.testCases.reduce(into: [String: (container: UIViewController, contained: VC)]()) { dict, entry in
-        let identifier = entry.key
-        let containedVC = entry.value
+      return self.testCases.reduce(into: [String: (container: UIViewController, contained: VC)]()) { dict, identifier in
+        let containedVC = vc()
         let containerVC = container.container(for: containedVC as! UIViewController)
         dict[identifier] = (container: containerVC, contained: containedVC)
       }

--- a/Tempura/UITests/UITests.swift
+++ b/Tempura/UITests/UITests.swift
@@ -32,14 +32,12 @@ public enum UITests {
   
   
   public struct VCScreenSnapshot<VC: AnyViewController> {
-    let vc: () -> VC
     let container: Container
-    let testCases: [String]
+    let testCases: [String: VC]
     let hooks: [Hook: HookClosure<VC.V>]
     let size: CGSize
     
-    init(vc: @autoclosure @escaping () -> VC, container: Container, testCases: [String], hooks: [Hook: HookClosure<VC.V>], size: CGSize) {
-      self.vc = vc
+    init(container: Container, testCases: [String: VC], hooks: [Hook: HookClosure<VC.V>], size: CGSize) {
       self.container = container
       self.testCases = testCases
       self.hooks = hooks
@@ -47,8 +45,9 @@ public enum UITests {
     }
     
     public var renderingViewControllers: [String: (container: UIViewController, contained: VC)] {
-      return self.testCases.reduce(into: [String: (container: UIViewController, contained: VC)]()) { dict, identifier in
-        let containedVC = vc()
+      return self.testCases.reduce(into: [String: (container: UIViewController, contained: VC)]()) { dict, entry in
+        let identifier = entry.key
+        let containedVC = entry.value
         let containerVC = container.container(for: containedVC as! UIViewController)
         dict[identifier] = (container: containerVC, contained: containedVC)
       }

--- a/Tempura/UITests/UITests.swift
+++ b/Tempura/UITests/UITests.swift
@@ -46,14 +46,11 @@ public enum UITests {
       self.size = size
     }
     
-    public var renderingViewControllers: [String: (container: UIViewController, contained: VC)] {
-      return self.testCases.reduce(into: [String: (container: UIViewController, contained: VC)]()) { dict, identifier in
-        let containedVC = vc()
-        let containerVC = container.container(for: containedVC as! UIViewController)
-        dict[identifier] = (container: containerVC, contained: containedVC)
-      }
+    public func renderingViewController(for identifier: String) -> (container: UIViewController, contained: VC) {
+      let containedVC = vc()
+      let containerVC = container.container(for: containedVC as! UIViewController)
+      return (container: containerVC, contained: containedVC)
     }
-    
   }
   
   public struct ScreenSnapshot<V: ViewControllerModellableView> {
@@ -258,11 +255,17 @@ public enum UITests {
     self.saveImage(image, description: description)
   }
   
-  static func asyncSnapshot(view: UIView, viewToWaitFor: UIView? = nil, description: String, isViewReadyClosure: @escaping (UIView) -> Bool, shouldRenderSafeArea: Bool, completionClosure: @escaping () -> Void) {
+  static func asyncSnapshot(view: UIView,
+                            viewToWaitFor: UIView? = nil,
+                            description: String,
+                            configureClosure: ((UIViewController) -> Void)? = nil,
+                            isViewReadyClosure: @escaping (UIView) -> Bool,
+                            shouldRenderSafeArea: Bool,
+                            completionClosure: @escaping () -> Void) {
     let frame = UIScreen.main.bounds
     view.frame = frame
     
-    view.snapshotAsync(viewToWaitFor: viewToWaitFor, isViewReadyClosure: isViewReadyClosure, shouldRenderSafeArea: shouldRenderSafeArea) { snapshot in
+    view.snapshotAsync(viewToWaitFor: viewToWaitFor, configureClosure: configureClosure, isViewReadyClosure: isViewReadyClosure, shouldRenderSafeArea: shouldRenderSafeArea) { snapshot in
       defer {
         completionClosure()
       }

--- a/Tempura/UITests/UITests.swift
+++ b/Tempura/UITests/UITests.swift
@@ -29,30 +29,6 @@ public enum UITests {
    Sometimes it is required to execute some arbitrary code during the view lifecycle.
    Hooks can be used to customize the behaviour of the mocked view controller that renders the view.
    */
-  
-  
-  public struct VCScreenSnapshot<VC: AnyViewController> {
-    let vc: () -> VC
-    let container: Container
-    let testCases: [String]
-    let hooks: [Hook: HookClosure<VC.V>]
-    let size: CGSize
-    
-    init(vc: @autoclosure @escaping () -> VC, container: Container, testCases: [String], hooks: [Hook: HookClosure<VC.V>], size: CGSize) {
-      self.vc = vc
-      self.container = container
-      self.testCases = testCases
-      self.hooks = hooks
-      self.size = size
-    }
-    
-    public func renderingViewController(for identifier: String) -> (container: UIViewController, contained: VC) {
-      let containedVC = vc()
-      let containerVC = container.container(for: containedVC as! UIViewController)
-      return (container: containerVC, contained: containedVC)
-    }
-  }
-  
   public struct ScreenSnapshot<V: ViewControllerModellableView> {
     let viewType: V.Type
     let models: [String: V.VM]
@@ -87,7 +63,6 @@ public enum UITests {
       self.hooks = hooks
     }
   }
-  
   
   /// A Renderer will take a type of View, a ViewModel, a Container and will create the rendering UIViewController
   /// that will be used to render the View.

--- a/Tempura/UITests/UITests.swift
+++ b/Tempura/UITests/UITests.swift
@@ -233,7 +233,7 @@ public enum UITests {
   static func asyncSnapshot(view: UIView,
                             viewToWaitFor: UIView? = nil,
                             description: String,
-                            configureClosure: ((UIViewController) -> Void)? = nil,
+                            configureClosure: (() -> Void)? = nil,
                             isViewReadyClosure: @escaping (UIView) -> Bool,
                             shouldRenderSafeArea: Bool,
                             completionClosure: @escaping () -> Void) {

--- a/Tempura/UITests/UIView+snapshot.swift
+++ b/Tempura/UITests/UIView+snapshot.swift
@@ -34,7 +34,7 @@ extension UIView {
     return snapshot
   }
   
-  func snapshotAsync(viewToWaitFor: UIView? = nil, isViewReadyClosure: @escaping (UIView) -> Bool, shouldRenderSafeArea: Bool, _ completionClosure: @escaping (UIImage?) -> Void) {
+  func snapshotAsync(viewToWaitFor: UIView? = nil, configureClosure: ((UIViewController) -> Void)?, isViewReadyClosure: @escaping (UIView) -> Bool, shouldRenderSafeArea: Bool, _ completionClosure: @escaping (UIImage?) -> Void) {
     let window: UIWindow?
     var removeFromSuperview: Bool = false
     
@@ -46,6 +46,10 @@ extension UIView {
       window = UIApplication.shared.keyWindow
       window?.addSubview(self)
       removeFromSuperview = true
+    }
+
+    if let vc = viewToWaitFor?.next as? UIViewController {
+      configureClosure?(vc)
     }
     
     self.layoutIfNeeded()

--- a/Tempura/UITests/UIView+snapshot.swift
+++ b/Tempura/UITests/UIView+snapshot.swift
@@ -35,7 +35,7 @@ extension UIView {
   }
   
   func snapshotAsync(viewToWaitFor: UIView? = nil,
-                     configureClosure: ((UIViewController) -> Void)?,
+                     configureClosure: (() -> Void)?,
                      isViewReadyClosure: @escaping (UIView) -> Bool,
                      shouldRenderSafeArea: Bool,
                      _ completionClosure: @escaping (UIImage?) -> Void) {
@@ -52,10 +52,8 @@ extension UIView {
       removeFromSuperview = true
     }
 
-    if let vc = viewToWaitFor?.next as? UIViewController {
-      configureClosure?(vc)
-    }
-    
+    configureClosure?()
+
     self.layoutIfNeeded()
     
     self.snapshotAsyncImpl(viewToWaitFor: viewToWaitFor, isViewReadyClosure: isViewReadyClosure, shouldRenderSafeArea: shouldRenderSafeArea) { snapshot in

--- a/Tempura/UITests/UIView+snapshot.swift
+++ b/Tempura/UITests/UIView+snapshot.swift
@@ -34,7 +34,11 @@ extension UIView {
     return snapshot
   }
   
-  func snapshotAsync(viewToWaitFor: UIView? = nil, configureClosure: ((UIViewController) -> Void)?, isViewReadyClosure: @escaping (UIView) -> Bool, shouldRenderSafeArea: Bool, _ completionClosure: @escaping (UIImage?) -> Void) {
+  func snapshotAsync(viewToWaitFor: UIView? = nil,
+                     configureClosure: ((UIViewController) -> Void)?,
+                     isViewReadyClosure: @escaping (UIView) -> Bool,
+                     shouldRenderSafeArea: Bool,
+                     _ completionClosure: @escaping (UIImage?) -> Void) {
     let window: UIWindow?
     var removeFromSuperview: Bool = false
     

--- a/Tempura/UITests/ViewControllerTestCase.swift
+++ b/Tempura/UITests/ViewControllerTestCase.swift
@@ -29,7 +29,7 @@ public protocol ViewControllerTestCase {
   /**
    Add new UI tests to be performed
    
-   - parameter testCases: an array of test cases, each element of the array will be used as input for the `configure(vc:for:)` method.
+   - parameter testCases: a dictionary of test cases and the corresponding view models. Each pair of the array will be used as input for the `configure(vc:for:model:)` method.
    - parameter context: a context used to pass information and control how the view should be rendered
    */
   func uiTest(testCases: [String: VC.V.VM], context: UITests.VCContext<VC>)
@@ -160,7 +160,7 @@ public extension ViewControllerTestCase {
     return true
   }
 
-  /// The default implementation does nothing
+  /// The default implementation sets the model of the root view to nil and then to the given model
   func configure(vc: VC, for testCase: String, model: VC.V.VM) {
     // Reset this to nil so that animation depending on changes of the model should be skipped
     vc.rootView.model = nil

--- a/Tempura/UITests/ViewControllerTestCase.swift
+++ b/Tempura/UITests/ViewControllerTestCase.swift
@@ -58,8 +58,8 @@ public protocol ViewControllerTestCase {
   var viewController: VC { get }
   
   /// configure the VC for the specified `testCase`
-  /// The ViewModel injection is already handled by the ViewControllerTestCase
-  func configure(vc: VC, for testCase: String)
+  /// this is typically used to manually inject the ViewModel to all the children VCs.
+  func configure(vc: VC, for testCase: String, viewModel: VC.V.VM)
 }
 
 
@@ -104,8 +104,7 @@ public extension ViewControllerTestCase where Self: XCTestCase {
         }
 
         let configureClosure: (UIViewController) -> Void = { vc in
-          self.viewController.rootView.model = viewModel
-          self.typeErasedConfigure(vc, identifier: identifier)
+          self.typeErasedConfigure(vc, identifier: identifier, viewModel: viewModel)
         }
 
         let dispatchGroup = DispatchGroup()
@@ -142,11 +141,15 @@ public extension ViewControllerTestCase where Self: XCTestCase {
     return self.isViewReady(view, identifier: identifier)
   }
 
-  func typeErasedConfigure(_ vc: UIViewController, identifier: String) -> Void {
-    guard let vc = vc as? VC else {
+  func typeErasedConfigure(_ vc: UIViewController, identifier: String, viewModel: ViewModel) -> Void {
+    guard
+      let vc = vc as? VC,
+      let viewModel = viewModel as? VC.V.VM
+    else {
       return
     }
-    self.configure(vc: vc, for: identifier)
+
+    self.configure(vc: vc, for: identifier, viewModel: viewModel)
   }
 }
 
@@ -157,7 +160,8 @@ public extension ViewControllerTestCase {
   }
 
   /// The default implementation does nothing
-  func configure(vc: VC, for testCase: String) {
+  func configure(vc: VC, for testCase: String, viewModel: VC.V.VM) {
+    vc.rootView.model = viewModel
   }
 
   func uiTest(testCases: [String: VC.V.VM]) {

--- a/Tempura/UITests/ViewControllerTestCase.swift
+++ b/Tempura/UITests/ViewControllerTestCase.swift
@@ -24,7 +24,7 @@ import Tempura
  */
 
 public protocol ViewControllerTestCase {
-  associatedtype VC: AnyViewController
+  associatedtype VC: AnyViewController & UIViewController
   
   /**
    Add new UI tests to be performed
@@ -82,7 +82,7 @@ public extension ViewControllerTestCase where Self: XCTestCase {
         var container: UIViewController!
         DispatchQueue.main.sync {
           contained = self.viewController
-          container = context.container.container(for: contained as! UIViewController)
+          container = context.container.container(for: contained)
         }
 
         guard let description = descriptions[identifier] else { continue }
@@ -113,7 +113,7 @@ public extension ViewControllerTestCase where Self: XCTestCase {
         DispatchQueue.main.async {
           UITests.asyncSnapshot(
             view: container.view,
-            viewToWaitFor: contained.rootView,
+            viewToWaitFor: contained.view,
             description: description,
             configureClosure: configureClosure,
             isViewReadyClosure: isViewReadyClosure,

--- a/Tempura/UITests/ViewControllerTestCase.swift
+++ b/Tempura/UITests/ViewControllerTestCase.swift
@@ -59,7 +59,7 @@ public protocol ViewControllerTestCase {
   
   /// configure the VC for the specified `testCase`
   /// this is typically used to manually inject the ViewModel to all the children VCs.
-  func configure(vc: VC, for testCase: String, viewModel: VC.V.VM)
+  func configure(vc: VC, for testCase: String, model: VC.V.VM)
 }
 
 
@@ -77,7 +77,7 @@ public extension ViewControllerTestCase where Self: XCTestCase {
     XCUIDevice.shared.orientation = context.orientation
 
     DispatchQueue.global().async {
-      for (identifier, viewModel) in testCases {
+      for (identifier, model) in testCases {
         let contained = self.viewController
         var container: UIViewController?
         DispatchQueue.main.sync {
@@ -104,7 +104,7 @@ public extension ViewControllerTestCase where Self: XCTestCase {
         }
 
         let configureClosure: (UIViewController) -> Void = { vc in
-          self.typeErasedConfigure(vc, identifier: identifier, viewModel: viewModel)
+          self.typeErasedConfigure(vc, identifier: identifier, model: model)
         }
 
         let dispatchGroup = DispatchGroup()
@@ -141,15 +141,15 @@ public extension ViewControllerTestCase where Self: XCTestCase {
     return self.isViewReady(view, identifier: identifier)
   }
 
-  func typeErasedConfigure(_ vc: UIViewController, identifier: String, viewModel: ViewModel) -> Void {
+  func typeErasedConfigure(_ vc: UIViewController, identifier: String, model: ViewModel) -> Void {
     guard
       let vc = vc as? VC,
-      let viewModel = viewModel as? VC.V.VM
+      let model = model as? VC.V.VM
     else {
       return
     }
 
-    self.configure(vc: vc, for: identifier, viewModel: viewModel)
+    self.configure(vc: vc, for: identifier, model: model)
   }
 }
 
@@ -160,8 +160,8 @@ public extension ViewControllerTestCase {
   }
 
   /// The default implementation does nothing
-  func configure(vc: VC, for testCase: String, viewModel: VC.V.VM) {
-    vc.rootView.model = viewModel
+  func configure(vc: VC, for testCase: String, model: VC.V.VM) {
+    vc.rootView.model = model
   }
 
   func uiTest(testCases: [String: VC.V.VM]) {

--- a/Tempura/UITests/ViewControllerTestCase.swift
+++ b/Tempura/UITests/ViewControllerTestCase.swift
@@ -78,8 +78,8 @@ public extension ViewControllerTestCase where Self: XCTestCase {
 
     DispatchQueue.global().async {
       for (identifier, model) in testCases {
-        var contained: VC?
-        var container: UIViewController?
+        var contained: VC!
+        var container: UIViewController!
         DispatchQueue.main.sync {
           contained = self.viewController
           container = context.container.container(for: contained as! UIViewController)
@@ -112,14 +112,14 @@ public extension ViewControllerTestCase where Self: XCTestCase {
         dispatchGroup.enter()
         DispatchQueue.main.async {
           UITests.asyncSnapshot(
-            view: container!.view,
-            viewToWaitFor: (contained as! UIViewController).view,
+            view: container.view,
+            viewToWaitFor: contained.rootView,
             description: description,
             configureClosure: configureClosure,
             isViewReadyClosure: isViewReadyClosure,
             shouldRenderSafeArea: context.renderSafeArea) {
             // ScrollViews snapshot
-            self.scrollViewsToTest(in: contained!, identifier: identifier).forEach { entry in
+            self.scrollViewsToTest(in: contained, identifier: identifier).forEach { entry in
               UITests.snapshotScrollableContent(entry.value, description: "\(identifier)_scrollable_content \(screenSizeDescription)")
             }
             dispatchGroup.leave()

--- a/Tempura/UITests/ViewControllerTestCase.swift
+++ b/Tempura/UITests/ViewControllerTestCase.swift
@@ -32,7 +32,7 @@ public protocol ViewControllerTestCase {
    - parameter testCases: an array of test cases, each element of the array will be used as input for the `configure(vc:for:)` method.
    - parameter context: a context used to pass information and control how the view should be rendered
    */
-  func uiTest(testCases: [String: VC], context: UITests.VCContext<VC>)
+  func uiTest(testCases: [String], context: UITests.VCContext<VC>)
   
   /// Retrieves a dictionary containing the scrollable subviews to test.
   /// The snapshot will contain the whole scrollView content.
@@ -51,12 +51,22 @@ public protocol ViewControllerTestCase {
    - parameter identifier: the test case identifier
    */
   func isViewReady(_ view: VC.V, identifier: String) -> Bool
+  
+  /// used to provide the ViewController to test.
+  /// We cannot instantiate it as we cannot require an init in the AnyViewController protocol
+  /// otherwise it will require all of the subclasses to have it specified.
+  var viewController: VC { get }
+  
+  /// configure the VC for the specified `testCase`
+  /// this is typically used to manually inject the ViewModel to all the children VCs.
+  func configure(vc: VC, for testCase: String)
 }
 
 
 public extension ViewControllerTestCase where Self: XCTestCase {
-  func uiTest(testCases: [String: VC], context: UITests.VCContext<VC>) {
+  func uiTest(testCases: [String], context: UITests.VCContext<VC>) {
     let snapshotConfiguration = UITests.VCScreenSnapshot<VC>(
+      vc: self.viewController,
       container: context.container,
       testCases: testCases,
       hooks: context.hooks,
@@ -73,7 +83,7 @@ public extension ViewControllerTestCase where Self: XCTestCase {
       
       let expectation = XCTestExpectation(description: description)
       XCUIDevice.shared.orientation = context.orientation
-
+      
       let isViewReadyClosure: (UIView) -> Bool = { view in
         var isOrientationCorrect = true
         
@@ -86,9 +96,13 @@ public extension ViewControllerTestCase where Self: XCTestCase {
         } else if context.orientation.isLandscape {
           isOrientationCorrect = !isViewInPortrait
         }
-
+        
         let isReady = isOrientationCorrect && self.typeErasedIsViewReady(view, identifier: identifier)
-
+        
+        if isReady {
+          self.configure(vc: vcs.contained, for: identifier)
+        }
+        
         return isReady
       }
       
@@ -124,7 +138,7 @@ public extension ViewControllerTestCase {
     return true
   }
   
-  func uiTest(testCases: [String: VC]) {
+  func uiTest(testCases: [String]) {
     let standardContext = UITests.VCContext<VC>()
     self.uiTest(testCases: testCases, context: standardContext)
   }

--- a/Tempura/UITests/ViewControllerTestCase.swift
+++ b/Tempura/UITests/ViewControllerTestCase.swift
@@ -123,16 +123,13 @@ public extension ViewControllerTestCase where Self: XCTestCase {
             self.scrollViewsToTest(in: vcs.contained, identifier: identifier).forEach { entry in
               UITests.snapshotScrollableContent(entry.value, description: "\(identifier)_scrollable_content \(screenSizeDescription)")
             }
-            print("DF leaving  \(identifier): \(Date())")
             dispatchGroup.leave()
             expectations[identifier]?.fulfill()
           }
         }
 
         // wait for the test case to be completed before starting the next one
-        print("DF waiting \(identifier): \(Date())")
         dispatchGroup.wait()
-        print("DF done  \(identifier): \(Date())")
       }
     }
     

--- a/Tempura/UITests/ViewControllerTestCase.swift
+++ b/Tempura/UITests/ViewControllerTestCase.swift
@@ -104,10 +104,6 @@ public extension ViewControllerTestCase where Self: XCTestCase {
           return isReady
         }
 
-        let configureClosure: (UIViewController) -> Void = { vc in
-          self.typeErasedConfigure(vc, identifier: identifier, model: model)
-        }
-
         let dispatchGroup = DispatchGroup()
         dispatchGroup.enter()
         DispatchQueue.main.async {
@@ -115,7 +111,9 @@ public extension ViewControllerTestCase where Self: XCTestCase {
             view: container.view,
             viewToWaitFor: contained.view,
             description: description,
-            configureClosure: configureClosure,
+            configureClosure: {
+              self.typeErasedConfigure(contained, identifier: identifier, model: model)
+            },
             isViewReadyClosure: isViewReadyClosure,
             shouldRenderSafeArea: context.renderSafeArea) {
             // ScrollViews snapshot

--- a/Tempura/UITests/ViewControllerTestCase.swift
+++ b/Tempura/UITests/ViewControllerTestCase.swift
@@ -78,9 +78,10 @@ public extension ViewControllerTestCase where Self: XCTestCase {
 
     DispatchQueue.global().async {
       for (identifier, model) in testCases {
-        let contained = self.viewController
+        var contained: VC?
         var container: UIViewController?
         DispatchQueue.main.sync {
+          contained = self.viewController
           container = context.container.container(for: contained as! UIViewController)
         }
 
@@ -118,7 +119,7 @@ public extension ViewControllerTestCase where Self: XCTestCase {
             isViewReadyClosure: isViewReadyClosure,
             shouldRenderSafeArea: context.renderSafeArea) {
             // ScrollViews snapshot
-            self.scrollViewsToTest(in: contained, identifier: identifier).forEach { entry in
+            self.scrollViewsToTest(in: contained!, identifier: identifier).forEach { entry in
               UITests.snapshotScrollableContent(entry.value, description: "\(identifier)_scrollable_content \(screenSizeDescription)")
             }
             dispatchGroup.leave()

--- a/Tempura/UITests/ViewControllerTestCase.swift
+++ b/Tempura/UITests/ViewControllerTestCase.swift
@@ -162,6 +162,8 @@ public extension ViewControllerTestCase {
 
   /// The default implementation does nothing
   func configure(vc: VC, for testCase: String, model: VC.V.VM) {
+    // Reset this to nil so that animation depending on changes of the model should be skipped
+    vc.rootView.model = nil
     vc.rootView.model = model
   }
 


### PR DESCRIPTION
**Why**
In the current implementation, the `configure` method is called after the isViewReady, but in some cases we might want to wait some time after the configuration (e.g. to download a remote image)

**Changes**
ViewControllerTestCase uiTest method now accepts a dictionary of testId to VM.
The default configure implementation just sets the given VM to the view.

Instances of the same ViewControllerTestCase are now executed serially:
- configure of the first instance is called
- wait until isViewReady of the first instance is called
- take the snapshot
- configure of the second instance is called
- wait until isViewReady of the second instance is called
- take the snapshot
- ...

The ViewControllerTestCase.configure method is now called at the beginning of the test
**Tasks**
* [ ] Add relevant tests, if needed
* [x] Add documentation, if needed
* [x] Update README, if needed
* [x] Ensure that the demo project works properly