### PR TITLE
Support for keyboard rendering

### DIFF
--- a/DemoTests/DemoTests.swift
+++ b/DemoTests/DemoTests.swift
@@ -50,10 +50,10 @@ class ScreenTests: XCTestCase, ViewTestCase {
         "add_item_05": thirdTestViewModel
       ],
       context: UITests.Context<AddItemView>(
-        keyboardHeight: { testCase in
+        keyboardVisibility: { testCase in
           switch testCase {
-          case "add_item_05": return UITests.defaultKeyboardHeight()
-          default: return 0
+          case "add_item_05": return .defaultHeight
+          default: return .hidden
           }
         }
       )
@@ -100,10 +100,10 @@ class VCTests: XCTestCase, ViewControllerTestCase {
       "secondTestVM": secondTestVM,
       ],
       context: UITests.VCContext<VCTests.VC>(
-        keyboardHeight: { testCase in
+        keyboardVisibility: { testCase in
           switch testCase {
-          case "secondTestVM": return UITests.defaultKeyboardHeight()
-          default: return 0
+          case "secondTestVM": return .defaultHeight
+          default: return .hidden
           }
         }
       )

--- a/DemoTests/DemoTests.swift
+++ b/DemoTests/DemoTests.swift
@@ -5,12 +5,12 @@
 //  Created by Andrea De Angelis on 09/02/2018.
 //
 
-import XCTest
-@testable import Demo
+import Katana
 import Tempura
 import TempuraTesting
-import Katana
+import XCTest
 
+@testable import Demo
 
 class ScreenTests: XCTestCase, ViewTestCase {
 //  
@@ -52,7 +52,7 @@ class ScreenTests: XCTestCase, ViewTestCase {
       context: UITests.Context<AddItemView>(
         keyboardHeight: { testCase in
           switch testCase {
-          case "add_item_05": return UITests.defaultKeyboardHeight
+          case "add_item_05": return UITests.defaultKeyboardHeight()
           default: return 0
           }
         }
@@ -102,7 +102,7 @@ class VCTests: XCTestCase, ViewControllerTestCase {
       context: UITests.VCContext<VCTests.VC>(
         keyboardHeight: { testCase in
           switch testCase {
-          case "secondTestVM": return UITests.defaultKeyboardHeight
+          case "secondTestVM": return UITests.defaultKeyboardHeight()
           default: return 0
           }
         }

--- a/DemoTests/DemoTests.swift
+++ b/DemoTests/DemoTests.swift
@@ -30,19 +30,33 @@ class ScreenTests: XCTestCase, ViewTestCase {
   var thirdTestViewModel: AddItemViewModel {
     return AddItemViewModel(editingText: "what about this?")
   }
-  
+
   // Fourth test
   var fourthTestViewModel: AddItemViewModel {
     return AddItemViewModel(editingText: "this is a test with hooks")
   }
-  
+
+  // Fifth test
+  var fifthTestViewModel: AddItemViewModel {
+    return AddItemViewModel(editingText: "this is a test with keyboard")
+  }
+
   func testAddItemScreen() {
     self.uiTest(
       testCases: [
         "add_item_01": firstTestViewModel,
         "add_item_02": secondTestViewModel,
-        "add_item_03": thirdTestViewModel
-      ]
+        "add_item_03": thirdTestViewModel,
+        "add_item_05": thirdTestViewModel
+      ],
+      context: UITests.Context<AddItemView>(
+        keyboardHeight: { testCase in
+          switch testCase {
+          case "add_item_05": return UITests.defaultKeyboardHeight
+          default: return 0
+          }
+        }
+      )
     )
   }
   
@@ -75,7 +89,24 @@ class VCTests: XCTestCase, ViewControllerTestCase {
     return AddItemViewModel(editingText: "ViewController test")
   }
 
+  var secondTestVM: AddItemViewModel {
+    return AddItemViewModel(editingText: "ViewController with keyboard test")
+  }
+
   func testVC() {
-    self.uiTest(testCases: ["firstTest": firstTestVM], context: UITests.VCContext<VCTests.VC>())
+    self.uiTest(
+      testCases: [
+      "firstTest": firstTestVM,
+      "secondTestVM": secondTestVM,
+      ],
+      context: UITests.VCContext<VCTests.VC>(
+        keyboardHeight: { testCase in
+          switch testCase {
+          case "secondTestVM": return UITests.defaultKeyboardHeight
+          default: return 0
+          }
+        }
+      )
+    )
   }
 }

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ class UITests: XCTestCase, ViewTestCase {
 }
 
 ```
-If some important content inside a UIScrollView is not fully visibile, you can leverage the `scrollViewsToTest(in view: V, identifier: String)` method.
+If some important content inside a UIScrollView is not fully visible, you can leverage the `scrollViewsToTest(in view: V, identifier: String)` method.
 This will produce an additional snapshot rendering the full content of each returned UIScrollView instance.
 
 In this example we use `scrollViewsToTest(in view: V, identifier: String)`  to take an extended snapshot of the *mood picker* at the bottom of the screen.
@@ -236,7 +236,7 @@ func scrollViewsToTest(in view: V, identifier: String) -> [String: UIScrollView]
 
 
 In case you have to wait for asynchronous operations before rendering the UI and take the screenshot, you can leverage the `isViewReady(view:identifier:)` method.
-For instance, here we wait until an hypotetical view that shows an image from a remote URL is ready. When the image is shown (that is, the state is `loaded`, then the snapshot is taken)
+For instance, here we wait until an hypothetical view that shows an image from a remote URL is ready. When the image is shown (that is, the state is `loaded`, then the snapshot is taken)
 ```swift
 import TempuraTesting
 

--- a/README.md
+++ b/README.md
@@ -256,6 +256,15 @@ class UITests: XCTestCase, ViewTestCase {
 
 The test will pass as soon as the snapshot is taken.
 
+#### Context
+
+You can enable a number of advanced features through the `context` object that you can pass to the `uiTest` method: 
+- the `container` allows you to define a VC as a container of the view during the UITests. Basic `navigationController` and `tabBarController` are already provided, or you can define your own using the `custom` one 
+- the `hooks` allows you to perform actions when some lifecycle events happen. Available hooks are `viewDidLoad`, `viewWillAppear`, `viewDidAppear`, `viewDidLayoutSubviews`, and `navigationControllerHasBeenCreated`
+- the `screenSize` and `orientation` properties allows you to define a custom screen size and orientation to be used during the test
+- the `renderSafeArea` allows you to define whether the safe area should be rendered as semitransparent gray overlay during the test
+- the `keyboardVisibility` allows you to define whether a gray overlay should be rendered as a placeholder for the keyboard
+
 #### Multiple devices
 
 By default, tests are run only in the device you have choose from xcode (or your device, or CI system). We can run the snapshotting in all the devices by using a script like the following one:

--- a/Tempura/UITests/UITests.swift
+++ b/Tempura/UITests/UITests.swift
@@ -357,7 +357,7 @@ public extension UITests {
     /// The keyboard is visible with the specified height
     case customHeight(CGFloat)
 
-    func height(for orientation: UIDeviceOrientation) -> CGFloat {
+    public func height(for orientation: UIDeviceOrientation = .portrait) -> CGFloat {
       switch self {
       case .hidden:
         return 0

--- a/Tempura/UITests/UITests.swift
+++ b/Tempura/UITests/UITests.swift
@@ -356,29 +356,33 @@ public extension UITests {
     /// The keyboard is visible with the specified height
     case customHeight(CGFloat)
 
-    func height(for orientation: UIDeviceOrientation = .portrait) -> CGFloat {
+    func height(for orientation: UIDeviceOrientation) -> CGFloat {
       switch self {
       case .hidden:
         return 0
       case .customHeight(let height):
         return height
       case .defaultHeight:
-        switch max(UIScreen.main.bounds.height, UIScreen.main.bounds.width) {
-        case 0...667: // up to iPhone 8
-          return orientation.isLandscape ? 171 : 216
-        case 668...736: // 7 Plus, and 8 Plus
-          return orientation.isLandscape ? 162 : 226
-        case 737...812: // X, Xs, 11 Pro
-          return orientation.isLandscape ? 171 : 291
-        case 813...1023: // all the other phones
-          return orientation.isLandscape ? 171 : 301
-        case 1024...1193: // smaller iPads
-          return orientation.isLandscape ? 320 : 408
-        case 1194...1365: // iPads Pro 11"
-          return orientation.isLandscape ? 340 : 428
-        default: // bigger iPads
-          return orientation.isLandscape ? 403 : 498
-        }
+        return Self.defaultHeight(for: orientation)
+      }
+    }
+
+    public static func defaultHeight(for orientation: UIDeviceOrientation = .portrait) -> CGFloat {
+      switch max(UIScreen.main.bounds.height, UIScreen.main.bounds.width) {
+      case 0...667: // up to iPhone 8
+        return orientation.isLandscape ? 171 : 216
+      case 668...736: // 7 Plus, and 8 Plus
+        return orientation.isLandscape ? 162 : 226
+      case 737...812: // X, Xs, 11 Pro
+        return orientation.isLandscape ? 171 : 291
+      case 813...1023: // all the other phones
+        return orientation.isLandscape ? 171 : 301
+      case 1024...1193: // smaller iPads
+        return orientation.isLandscape ? 320 : 408
+      case 1194...1365: // iPads Pro 11"
+        return orientation.isLandscape ? 340 : 428
+      default: // bigger iPads
+        return orientation.isLandscape ? 403 : 498
       }
     }
   }

--- a/Tempura/UITests/UITests.swift
+++ b/Tempura/UITests/UITests.swift
@@ -236,7 +236,7 @@ public enum UITests {
                             configureClosure: ((UIViewController) -> Void)? = nil,
                             isViewReadyClosure: @escaping (UIView) -> Bool,
                             shouldRenderSafeArea: Bool,
-                            keyboardHeight: CGFloat,
+                            keyboardVisibility: KeyboardVisibility,
                             completionClosure: @escaping () -> Void) {
     let frame = UIScreen.main.bounds
     view.frame = frame
@@ -246,7 +246,7 @@ public enum UITests {
       configureClosure: configureClosure,
       isViewReadyClosure: isViewReadyClosure,
       shouldRenderSafeArea: shouldRenderSafeArea,
-      keyboardHeight: keyboardHeight
+      keyboardVisibility: keyboardVisibility
     ) { snapshot in
       defer {
         completionClosure()
@@ -345,24 +345,41 @@ extension CGSize {
 }
 
 public extension UITests {
-  /// Returns a realistic height of the keyboard, based on the device height.
-  /// These are empirical values, as there is no way to show a keyboard in the UITests or to get its height programmatically
-  static func defaultKeyboardHeight(for orientation: UIDeviceOrientation = .portrait) -> CGFloat {
-    switch max(UIScreen.main.bounds.height, UIScreen.main.bounds.width) {
-    case 0...667: // up to iPhone 8
-      return orientation.isLandscape ? 171 : 216
-    case 668...736: // 7 Plus, and 8 Plus
-      return orientation.isLandscape ? 162 : 226
-    case 737...812: // X, Xs, 11 Pro
-      return orientation.isLandscape ? 171 : 291
-    case 813...1023: // all the other phones
-      return orientation.isLandscape ? 171 : 301
-    case 1024...1193: // smaller iPads
-      return orientation.isLandscape ? 320 : 408
-    case 1194...1365: // iPads Pro 11"
-      return orientation.isLandscape ? 340 : 428
-    default: // bigger iPads
-      return orientation.isLandscape ? 403 : 498
+  enum KeyboardVisibility {
+    /// The keyboard is not visible
+    case hidden
+
+    /// The keyboard is visible with a realistic height of the keyboard, based on the device height.
+    /// These are empirical values, as there is no way to show a keyboard in the UITests or to get its height programmatically
+    case defaultHeight
+
+    /// The keyboard is visible with the specified height
+    case customHeight(CGFloat)
+
+    func height(for orientation: UIDeviceOrientation = .portrait) -> CGFloat {
+      switch self {
+      case .hidden:
+        return 0
+      case .customHeight(let height):
+        return height
+      case .defaultHeight:
+        switch max(UIScreen.main.bounds.height, UIScreen.main.bounds.width) {
+        case 0...667: // up to iPhone 8
+          return orientation.isLandscape ? 171 : 216
+        case 668...736: // 7 Plus, and 8 Plus
+          return orientation.isLandscape ? 162 : 226
+        case 737...812: // X, Xs, 11 Pro
+          return orientation.isLandscape ? 171 : 291
+        case 813...1023: // all the other phones
+          return orientation.isLandscape ? 171 : 301
+        case 1024...1193: // smaller iPads
+          return orientation.isLandscape ? 320 : 408
+        case 1194...1365: // iPads Pro 11"
+          return orientation.isLandscape ? 340 : 428
+        default: // bigger iPads
+          return orientation.isLandscape ? 403 : 498
+        }
+      }
     }
   }
 }

--- a/Tempura/UITests/UITests.swift
+++ b/Tempura/UITests/UITests.swift
@@ -345,19 +345,24 @@ extension CGSize {
 }
 
 public extension UITests {
-  /// This returns a realistic height of the keyboard, based on the device height.
-  /// This is an heuristic, as there is no way to show a keyboard in the ui tests, but there is the need to simulate one
-  static var defaultKeyboardHeight: CGFloat {
-    switch UIScreen.main.bounds.height {
-    case 0...667:
-      // basically iPhone SE and iPhone 8
-      return 216
-    case 668...736:
-      // basically iPhone 8 Plus
-      return 226
-    default:
-      // all the other devices
-      return 291
+  /// Returns a realistic height of the keyboard, based on the device height.
+  /// These are empirical values, as there is no way to show a keyboard in the UITests or to get its height programmatically
+  static func defaultKeyboardHeight(for orientation: UIDeviceOrientation = .portrait) -> CGFloat {
+    switch max(UIScreen.main.bounds.height, UIScreen.main.bounds.width) {
+    case 0...667: // up to iPhone 8
+      return orientation.isLandscape ? 171 : 216
+    case 668...736: // 7 Plus, and 8 Plus
+      return orientation.isLandscape ? 162 : 226
+    case 737...812: // X, Xs, 11 Pro
+      return orientation.isLandscape ? 171 : 291
+    case 813...1023: // all the other phones
+      return orientation.isLandscape ? 171 : 301
+    case 1024...1193: // smaller iPads
+      return orientation.isLandscape ? 320 : 408
+    case 1194...1365: // iPads Pro 11"
+      return orientation.isLandscape ? 340 : 428
+    default: // bigger iPads
+      return orientation.isLandscape ? 403 : 498
     }
   }
 }

--- a/Tempura/UITests/UITests.swift
+++ b/Tempura/UITests/UITests.swift
@@ -345,6 +345,7 @@ extension CGSize {
 }
 
 public extension UITests {
+  /// Whether a box representing the keyboard should be rendered on top of the tested view
   enum KeyboardVisibility {
     /// The keyboard is not visible
     case hidden

--- a/Tempura/UITests/UITests.swift
+++ b/Tempura/UITests/UITests.swift
@@ -236,11 +236,18 @@ public enum UITests {
                             configureClosure: ((UIViewController) -> Void)? = nil,
                             isViewReadyClosure: @escaping (UIView) -> Bool,
                             shouldRenderSafeArea: Bool,
+                            keyboardHeight: CGFloat,
                             completionClosure: @escaping () -> Void) {
     let frame = UIScreen.main.bounds
     view.frame = frame
     
-    view.snapshotAsync(viewToWaitFor: viewToWaitFor, configureClosure: configureClosure, isViewReadyClosure: isViewReadyClosure, shouldRenderSafeArea: shouldRenderSafeArea) { snapshot in
+    view.snapshotAsync(
+      viewToWaitFor: viewToWaitFor,
+      configureClosure: configureClosure,
+      isViewReadyClosure: isViewReadyClosure,
+      shouldRenderSafeArea: shouldRenderSafeArea,
+      keyboardHeight: keyboardHeight
+    ) { snapshot in
       defer {
         completionClosure()
       }
@@ -334,5 +341,23 @@ public func test<V: ViewControllerModellableView & UIView>(_ viewType: V.Type,
 extension CGSize {
   public var description: String {
     return "\(Int(self.width))x\(Int(self.height))"
+  }
+}
+
+public extension UITests {
+  /// This returns a realistic height of the keyboard, based on the device height.
+  /// This is an heuristic, as there is no way to show a keyboard in the ui tests, but there is the need to simulate one
+  static var defaultKeyboardHeight: CGFloat {
+    switch UIScreen.main.bounds.height {
+    case 0...667:
+      // basically iPhone SE and iPhone 8
+      return 216
+    case 668...736:
+      // basically iPhone 8 Plus
+      return 226
+    default:
+      // all the other devices
+      return 291
+    }
   }
 }

--- a/Tempura/UITests/ViewControllerTestCase.swift
+++ b/Tempura/UITests/ViewControllerTestCase.swift
@@ -118,7 +118,7 @@ public extension ViewControllerTestCase where Self: XCTestCase {
             configureClosure: configureClosure,
             isViewReadyClosure: isViewReadyClosure,
             shouldRenderSafeArea: context.renderSafeArea,
-            keyboardHeight: context.keyboardHeight(identifier)
+            keyboardVisibility: context.keyboardVisibility(identifier)
             ) {
             // ScrollViews snapshot
             self.scrollViewsToTest(in: contained!, identifier: identifier).forEach { entry in
@@ -192,19 +192,19 @@ extension UITests {
     /// whether black dimmed rectangles should be rendered showing the safe area insets
     public var renderSafeArea: Bool
 
-    /// the height of the keyboard to be rendered on top of the view, for a given test case
-    public var keyboardHeight: (String) -> CGFloat
+    /// whether gray rectangle representing the keyboard should be rendered on top of the view, for a given test case
+    public var keyboardVisibility: (String) -> KeyboardVisibility
 
     public init(container: Container = .none,
                 screenSize: CGSize = UIScreen.main.bounds.size,
                 orientation: UIDeviceOrientation = .portrait,
                 renderSafeArea: Bool = true,
-                keyboardHeight: @escaping (String) -> CGFloat = { _ in 0 }) {
+                keyboardVisibility: @escaping (String) -> KeyboardVisibility = { _ in .hidden }) {
       self.container = container
       self.screenSize = screenSize
       self.orientation = orientation
       self.renderSafeArea = renderSafeArea
-      self.keyboardHeight = keyboardHeight
+      self.keyboardVisibility = keyboardVisibility
     }
   }
 }

--- a/Tempura/UITests/ViewControllerTestCase.swift
+++ b/Tempura/UITests/ViewControllerTestCase.swift
@@ -202,7 +202,7 @@ extension UITests {
                 hooks: [UITests.Hook: UITests.HookClosure<VC.V>] = [:],
                 screenSize: CGSize = UIScreen.main.bounds.size,
                 orientation: UIDeviceOrientation = .portrait,
-                renderSafeArea: Bool = false,
+                renderSafeArea: Bool = true,
                 keyboardHeight: @escaping (String) -> CGFloat = { _ in 0 }) {
       self.container = container
       self.hooks = hooks

--- a/Tempura/UITests/ViewControllerTestCase.swift
+++ b/Tempura/UITests/ViewControllerTestCase.swift
@@ -182,10 +182,7 @@ extension UITests {
     
     /// the container in which the main view of the VC will be embedded
     public var container: UITests.Container
-    
-    /// some hooks that can be added to customize the view after its creation
-    public var hooks: [UITests.Hook: UITests.HookClosure<VC.V>]
-    
+
     /// the size of the window in which the view will be rendered
     public var screenSize: CGSize
     
@@ -199,13 +196,11 @@ extension UITests {
     public var keyboardHeight: (String) -> CGFloat
 
     public init(container: Container = .none,
-                hooks: [UITests.Hook: UITests.HookClosure<VC.V>] = [:],
                 screenSize: CGSize = UIScreen.main.bounds.size,
                 orientation: UIDeviceOrientation = .portrait,
                 renderSafeArea: Bool = true,
                 keyboardHeight: @escaping (String) -> CGFloat = { _ in 0 }) {
       self.container = container
-      self.hooks = hooks
       self.screenSize = screenSize
       self.orientation = orientation
       self.renderSafeArea = renderSafeArea

--- a/Tempura/UITests/ViewControllerTestCase.swift
+++ b/Tempura/UITests/ViewControllerTestCase.swift
@@ -117,7 +117,9 @@ public extension ViewControllerTestCase where Self: XCTestCase {
             description: description,
             configureClosure: configureClosure,
             isViewReadyClosure: isViewReadyClosure,
-            shouldRenderSafeArea: context.renderSafeArea) {
+            shouldRenderSafeArea: context.renderSafeArea,
+            keyboardHeight: context.keyboardHeight(identifier)
+            ) {
             // ScrollViews snapshot
             self.scrollViewsToTest(in: contained!, identifier: identifier).forEach { entry in
               UITests.snapshotScrollableContent(entry.value, description: "\(identifier)_scrollable_content \(screenSizeDescription)")
@@ -192,17 +194,22 @@ extension UITests {
 
     /// whether black dimmed rectangles should be rendered showing the safe area insets
     public var renderSafeArea: Bool
-    
+
+    /// the height of the keyboard to be rendered on top of the view, for a given test case
+    public var keyboardHeight: (String) -> CGFloat
+
     public init(container: Container = .none,
                 hooks: [UITests.Hook: UITests.HookClosure<VC.V>] = [:],
                 screenSize: CGSize = UIScreen.main.bounds.size,
                 orientation: UIDeviceOrientation = .portrait,
-                renderSafeArea: Bool = false) {
+                renderSafeArea: Bool = false,
+                keyboardHeight: @escaping (String) -> CGFloat = { _ in 0 }) {
       self.container = container
       self.hooks = hooks
       self.screenSize = screenSize
       self.orientation = orientation
       self.renderSafeArea = renderSafeArea
+      self.keyboardHeight = keyboardHeight
     }
   }
 }

--- a/Tempura/UITests/ViewTestCase.swift
+++ b/Tempura/UITests/ViewTestCase.swift
@@ -97,7 +97,8 @@ public extension ViewTestCase where Self: XCTestCase {
                             viewToWaitFor: vcs.contained.view,
                             description: description,
                             isViewReadyClosure: isViewReadyClosure,
-                            shouldRenderSafeArea: context.renderSafeArea) {
+                            shouldRenderSafeArea: context.renderSafeArea,
+                            keyboardHeight: context.keyboardHeight(identifier)) {
                               // ScrollViews snapshot
                               self.scrollViewsToTest(in: vcs.contained.view as! V, identifier: identifier).forEach { entry in
                                 UITests.snapshotScrollableContent(entry.value, description: "\(identifier)_scrollable_content \(screenSizeDescription)")
@@ -153,17 +154,22 @@ extension UITests {
 
     /// whether black dimmed rectangles should be rendered showing the safe area insets
     public var renderSafeArea: Bool
-    
+
+    /// the height of the keyboard to be rendered on top of the view, for a given test case
+    public var keyboardHeight: (String) -> CGFloat
+
     public init(container: Container = .none,
                 hooks: [UITests.Hook: UITests.HookClosure<V>] = [:],
                 screenSize: CGSize = UIScreen.main.bounds.size,
                 orientation: UIDeviceOrientation = .portrait,
-                renderSafeArea: Bool = false) {
+                renderSafeArea: Bool = false,
+                keyboardHeight: @escaping (String) -> CGFloat = { _ in 0 }) {
       self.container = container
       self.hooks = hooks
       self.screenSize = screenSize
       self.orientation = orientation
       self.renderSafeArea = renderSafeArea
+      self.keyboardHeight = keyboardHeight
     }
   }
 }

--- a/Tempura/UITests/ViewTestCase.swift
+++ b/Tempura/UITests/ViewTestCase.swift
@@ -162,7 +162,7 @@ extension UITests {
                 hooks: [UITests.Hook: UITests.HookClosure<V>] = [:],
                 screenSize: CGSize = UIScreen.main.bounds.size,
                 orientation: UIDeviceOrientation = .portrait,
-                renderSafeArea: Bool = false,
+                renderSafeArea: Bool = true,
                 keyboardHeight: @escaping (String) -> CGFloat = { _ in 0 }) {
       self.container = container
       self.hooks = hooks

--- a/Tempura/UITests/ViewTestCase.swift
+++ b/Tempura/UITests/ViewTestCase.swift
@@ -98,7 +98,7 @@ public extension ViewTestCase where Self: XCTestCase {
                             description: description,
                             isViewReadyClosure: isViewReadyClosure,
                             shouldRenderSafeArea: context.renderSafeArea,
-                            keyboardHeight: context.keyboardHeight(identifier)) {
+                            keyboardVisibility: context.keyboardVisibility(identifier)) {
                               // ScrollViews snapshot
                               self.scrollViewsToTest(in: vcs.contained.view as! V, identifier: identifier).forEach { entry in
                                 UITests.snapshotScrollableContent(entry.value, description: "\(identifier)_scrollable_content \(screenSizeDescription)")
@@ -155,21 +155,21 @@ extension UITests {
     /// whether black dimmed rectangles should be rendered showing the safe area insets
     public var renderSafeArea: Bool
 
-    /// the height of the keyboard to be rendered on top of the view, for a given test case
-    public var keyboardHeight: (String) -> CGFloat
+    /// whether gray rectangle representing the keyboard should be rendered on top of the view, for a given test case
+    public var keyboardVisibility: (String) -> KeyboardVisibility
 
     public init(container: Container = .none,
                 hooks: [UITests.Hook: UITests.HookClosure<V>] = [:],
                 screenSize: CGSize = UIScreen.main.bounds.size,
                 orientation: UIDeviceOrientation = .portrait,
                 renderSafeArea: Bool = true,
-                keyboardHeight: @escaping (String) -> CGFloat = { _ in 0 }) {
+                keyboardVisibility: @escaping (String) -> KeyboardVisibility = { _ in .hidden }) {
       self.container = container
       self.hooks = hooks
       self.screenSize = screenSize
       self.orientation = orientation
       self.renderSafeArea = renderSafeArea
-      self.keyboardHeight = keyboardHeight
+      self.keyboardVisibility = keyboardVisibility
     }
   }
 }


### PR DESCRIPTION
**Why**
Some times in the UITests we want to test scenarios in which the keyboard is shown, but there is no way to render an actual keyboard in UITests

**Changes**
Added `keyboardVisibilty` callback in `UITests.Context` and `UITests.VCContext` which can be used to decide wether the keyboard should be displayed or not.
An alternative to put it in the context would be to put it as a function in ViewTestCase and ViewControllerTestCase, I have put it in the context for consistency with the renderSafeArea.
Possible values are: hidden (keyboard not shown), defaultHeight (keyboard shown with an height estimated from the device height and orientation), customHeight (keyboard shown with an user provided height)
If the provided keyboard height is not 0, a grey box of the given height is rendered at the bottom of the screen.
A UITests.KeyboardVisibility.defaultHeight function is also provided in order to obtain the height to be set in ViewModels if needed.

Other changes:
- changed the default value of `renderSafeArea` to true
- removed hooks from ViewControllerTestCase as they were not wired

**Tasks**
* [x] Add relevant tests, if needed
* [ ] Add documentation, if needed
* [ ] Update README, if needed
* [x] Ensure that the demo project works properly