### PR TITLE
fix: change pinLayout of sendToArchiveButton button in ListView

### DIFF
--- a/Demo/UI/ListScreen/ListView.swift
+++ b/Demo/UI/ListScreen/ListView.swift
@@ -164,9 +164,8 @@ class ListView: UIView, ViewControllerModellableView {
     self.todoListView.frame = self.scrollView.frame.bounds
     self.archiveListView.frame = self.todoListView.frame.offsetBy(dx: self.scrollView.bounds.width, dy: 0)
     guard let model = self.model else { return }
-    self.sendToArchiveButton.pin.bottom(self.universalSafeAreaInsets.bottom + 70)
     if model.containsArchivableItems && model.selectedSection == .todo {
-      self.sendToArchiveButton.pin.bottom(self.universalSafeAreaInsets.bottom + 70)
+      self.sendToArchiveButton.pin.hCenter().bottom(self.universalSafeAreaInsets.bottom + 85).height(6%).width(60%)
       let bottomInset = self.frame.height - self.sendToArchiveButton.frame.minY
       self.todoListView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: bottomInset, right: 0)
     } else {


### PR DESCRIPTION
**Why**
With the previous pinLayout, sendToArchiveButton was hidden in the UI.

**Changes**
Now the sendToArchiveButton button is visible in the UI and it is usable

**Tasks**
* [x] Ensure that the demo project works properly