### PR TITLE
Fix screenSize in UITests

### DIFF
--- a/Tempura/UITests/UITests.swift
+++ b/Tempura/UITests/UITests.swift
@@ -239,8 +239,6 @@ public enum UITests {
                             shouldRenderSafeArea: Bool,
                             keyboardVisibility: KeyboardVisibility,
                             completionClosure: @escaping () -> Void) {
-    let frame = UIScreen.main.bounds
-    view.frame = frame
     
     view.snapshotAsync(
       viewToWaitFor: viewToWaitFor,

--- a/Tempura/UITests/UIViewControllerTestCase.swift
+++ b/Tempura/UITests/UIViewControllerTestCase.swift
@@ -92,6 +92,7 @@ public extension UIViewControllerTestCase where Self: XCTestCase {
           contained = self.viewController
           container = context.container.container(for: contained)
           view = container.view
+          view.frame.size = context.screenSize
           viewToWaitFor = contained.view
         }
 

--- a/Tempura/UITests/ViewControllerTestCase.swift
+++ b/Tempura/UITests/ViewControllerTestCase.swift
@@ -108,6 +108,7 @@ public extension ViewControllerTestCase where Self: XCTestCase {
           contained = self.viewController
           container = context.container.container(for: contained)
           view = container.view
+          view.frame.size = context.screenSize
           viewToWaitFor = contained.view
         }
 


### PR DESCRIPTION
**Why**
At the moment `TempuraTesting` lets you set a different `screen size` but actually it doesn't take into account this value.
This PR fixes the problem.
The `syncSnapshot` and `asyncSnapshot` method should expect a view with the frame already set.

**Tasks**
* [ ] Add relevant tests, if needed
* [ ] Add documentation, if needed
* [ ] Update README, if needed
* [ ] Ensure that the demo project works properly