### PR TITLE
[Feature] SwiftUI

### DIFF
--- a/Tempura/Core/SwiftUIModellableView.swift
+++ b/Tempura/Core/SwiftUIModellableView.swift
@@ -1,0 +1,47 @@
+//
+//  SwiftUIModellableView.swift
+//  Tempura
+//
+//  Created by MicheleGruppioni on 01/12/20.
+//
+
+import Foundation
+#if canImport(SwiftUI)
+import SwiftUI
+#endif
+
+/// Basic protocol representing a SwiftUI View in Tempura.
+///
+/// Every SwiftUI View must conform to this protocol to be presented using Tempura.
+/// The viewModelProvider is the object that proxies the view updates from the Tempura
+/// environment to a SwiftUI ObservableObject.
+///
+/// ## Example
+/// ```swift
+/// struct SwiftUICustomView: SwiftUIModellableView {
+///   @ObservedObject var viewModelProvider: ViewModelProvider<SwiftUICustomViewModel>
+///
+///   init(viewModelProvider: ViewModelProvider<CustomViewModel>) {
+///     self.viewModelProvider = viewModelProvider
+///   }
+///
+///   var body: some SwiftUI.View {
+///     ...
+///   }
+/// }
+///
+/// struct SwiftUICustomViewModel: ViewModelWithState {
+///   init(state: AppState) {
+///     ...
+///   }
+/// }
+/// ```
+
+@available(iOS 13.0.0, *)
+public protocol SwiftUIModellableView: SwiftUI.View {
+  associatedtype VM: ViewModelWithState
+
+  var viewModelProvider: ViewModelProvider<VM> { get }
+
+  init(viewModelProvider: ViewModelProvider<VM>)
+}

--- a/Tempura/Core/SwiftUIViewControllerModellableView.swift
+++ b/Tempura/Core/SwiftUIViewControllerModellableView.swift
@@ -1,0 +1,83 @@
+//
+//  SwiftUIViewControllerModellableView.swift
+//  Tempura
+//
+//  Created by MicheleGruppioni on 01/12/20.
+//
+
+import UIKit
+#if canImport(SwiftUI)
+import SwiftUI
+#endif
+
+/// Special `ViewControllerModellableView` that adapt a `SwiftUIModellableView` to Tempura
+///
+/// This view present fullscreen a SwiftUI View that conforms to `SwiftUIModellableView` using a `UIHostingController`
+/// All the update events are forwaded to the SwiftUI world using a `ViewModelProvider`
+///
+/// ## Example
+/// ```swift
+/// class CustomViewController: ViewController<SwiftUIViewControllerModellableView<SwiftUICustomView>> {
+/// }
+/// ```
+
+@available(iOS 13.0.0, *)
+open class SwiftUIViewControllerModellableView<SwiftUIView: SwiftUIModellableView>: ContainerView, ViewControllerModellableView {
+  public typealias VM = SwiftUIView.VM
+
+  /// A ViewModelProvider used to forward the ViewModel updates to the SwiftUI View
+  private let viewModelProvider = ViewModelProvider<VM>()
+
+  // MARK: - Subviews
+
+  /// The `UIHostingController` used to embed a SwiftUI view in the current UIKit view hirearchy
+  private let hostingController: UIHostingController<SwiftUIView>
+
+  /// The embedded SwiftUI View
+  public var swiftUIView: SwiftUIView {
+    get {
+      hostingController.rootView
+    }
+    set {
+      hostingController.rootView = newValue
+    }
+  }
+
+  // MARK: - Init
+
+  public override init(frame: CGRect) {
+    let swiftUIView = SwiftUIView(viewModelProvider: self.viewModelProvider)
+    self.hostingController = UIHostingController(rootView: swiftUIView)
+
+    super.init(frame: frame)
+
+    self.setup()
+    self.style()
+  }
+
+  @available(*, unavailable)
+  public required init?(coder aDecoder: NSCoder) {
+    fatalError()
+  }
+
+  // MARK: - Setup
+
+  public func setup() {
+    if let viewController = self.viewController {
+      viewController.addChild(self.hostingController)
+      self.addSubview(self.hostingController.view)
+      self.hostingController.didMove(toParent: viewController)
+    }
+  }
+  
+  // MARK: - Style
+
+  public func style() {}
+
+  // MARK: - Update
+
+  public func update(oldModel: VM?) {
+    guard let model = self.model else { return }
+    self.viewModelProvider.update(model: model, oldModel: oldModel)
+  }
+}

--- a/Tempura/Core/ViewController+Containment.swift
+++ b/Tempura/Core/ViewController+Containment.swift
@@ -66,7 +66,7 @@ extension ViewController {
 
 /// A View used to do ViewController containment
 /// This is the View that will contain the View of the managed ViewController
-public class ContainerView: UIView {
+open class ContainerView: UIView {
   
   /// See `UIView.layoutSubviews()`
   public override func layoutSubviews() {

--- a/Tempura/Core/ViewModelProvider.swift
+++ b/Tempura/Core/ViewModelProvider.swift
@@ -1,0 +1,45 @@
+//
+//  ViewModelProvider.swift
+//  Tempura
+//
+//  Created by MicheleGruppioni on 01/12/20.
+//
+
+#if canImport(Combine)
+import Combine
+#endif
+#if canImport(SwiftUI)
+import SwiftUI
+#endif
+
+/// This object act as a proxy between the ViewModel updates in Tempura and SwiftUI.
+/// It's an `ObservableObject` so a SwiftUI view can subscribe to it using the `@ObservedObject` property wrapper.
+///
+/// This object is instantiated inside any `SwiftUIViewControllerModellableView`.
+
+@available(iOS 13.0.0, *)
+open class ViewModelProvider<VM: ViewModelWithState>: ObservableObject {
+  
+  /// Publisher requred by `ObservableObject` in order to update the SwiftUI View.
+  public let objectWillChange = ObservableObjectPublisher()
+
+  /// Last `oldModel` received.
+  private(set) var oldModel: VM?
+  
+  /// Last `model` received.
+  private(set) var model: VM?
+
+  /// Initialize a `ViewModelProvider` by setting the provided `model` and `oldModel`.
+  public init(model: VM? = nil, oldModel: VM? = nil) {
+    self.model = model
+    self.oldModel = oldModel
+  }
+
+  /// Perform an update of the models.
+  /// Everytime this method gets called a new `objectWillChange` events is emitted.
+  public func update(model: VM, oldModel: VM?) {
+    self.objectWillChange.send()
+    self.oldModel = oldModel
+    self.model = model
+  }
+}

--- a/Tempura/Core/ViewModelProvider.swift
+++ b/Tempura/Core/ViewModelProvider.swift
@@ -24,10 +24,10 @@ open class ViewModelProvider<VM: ViewModelWithState>: ObservableObject {
   public let objectWillChange = ObservableObjectPublisher()
 
   /// Last `oldModel` received.
-  private(set) var oldModel: VM?
+  public private(set) var oldModel: VM?
   
   /// Last `model` received.
-  private(set) var model: VM?
+  public private(set) var model: VM?
 
   /// Initialize a `ViewModelProvider` by setting the provided `model` and `oldModel`.
   public init(model: VM? = nil, oldModel: VM? = nil) {


### PR DESCRIPTION
## Why
Add the possibility to use SwiftUI instead of UIKit to create ViewController's views.
All the changes are optionals, no existing components were modified to add this feature.
It's possible to use SwiftUI to create a single view and the rest of the project can use UIKit without problems.

## Changes
All the work is done in 3 main components: `ViewModelProvider`, `SwiftUIViewControllerModellableView` and `SwiftUIModellableView`

The `ViewModelProvider` is the object that forwards the Katana's updates (`func update(oldModel: VM?)`) to the SwiftUI  `@ObservableObject` based architecture.

The `SwiftUIViewControllerModellableView` is a Tempura `ViewControllerModellableView` that emebds the SwiftUI View using a `UIHostingController` and forwards the updates to it using a `ViewModelProvider`

The `SwiftUIModellableView` is a protocol to which the SwiftUI Views must conform in order to receive the updates from the `ViewModelProvider`

## Other
### Naming
There are some naming collisions if you import SwiftUI and Tempura in the same file since they share some object names like `View`.

### Demo
We can consider to add a section related to this to the Demo project

**Tasks**
* [ ] Add relevant tests, if needed
* [ ] Add documentation, if needed
* [ ] Update README, if needed
* [x] Ensure that the demo project works properly