### PR TITLE
[Chore] Validate uniqueness of UI test keys

### DIFF
--- a/Tempura/UITests/UITestCaseKeyValidator.swift
+++ b/Tempura/UITests/UITestCaseKeyValidator.swift
@@ -1,0 +1,32 @@
+//
+//  UITestCaseKeyValidator.swift
+//  TempuraTesting
+//
+//  Created by Rouven Strauss on 07/01/2021.
+//
+
+import Foundation
+
+/// Mutable data structure for ensuring that sets of given keys are disjoint from previously provided keys.
+class UITestCaseKeyValidator {
+  /// Singleton instance of this class.
+  static let singletonInstance = UITestCaseKeyValidator()
+
+  /// Set of keys with which the `validate` method of this instance has been invoked.
+  private var keys = Set<String>()
+
+  /// Initializes a new instance.
+  private init() {}
+
+  /// Validates that the given `keys` are disjoint from any keys previously provided to this method. If a duplicate key is found,
+  /// the method fatally errs.
+  func validate(keys: Set<String>) {
+    guard self.keys.isDisjoint(with: keys) else {
+      fatalError("Key duplication: \(keys)")
+    }
+
+    keys.forEach {
+      self.keys.insert($0)
+    }
+  }
+}

--- a/Tempura/UITests/UITestCaseKeyValidator.swift
+++ b/Tempura/UITests/UITestCaseKeyValidator.swift
@@ -12,21 +12,22 @@ class UITestCaseKeyValidator {
   /// Singleton instance of this class.
   static let singletonInstance = UITestCaseKeyValidator()
 
-  /// Set of keys with which the `validate` method of this instance has been invoked.
-  private var keys = Set<String>()
+  /// Mapping of keys to test case names with which the `validate` method of this instance has been invoked.
+  private var keysToTestCaseNames = [String: String]()
 
   /// Initializes a new instance.
   private init() {}
 
-  /// Validates that the given `keys` are disjoint from any keys previously provided to this method. If a duplicate key is found,
-  /// the method fatally errs.
-  func validate(keys: Set<String>) {
-    guard self.keys.isDisjoint(with: keys) else {
-      fatalError("Key duplication: \(keys)")
-    }
+  /// Validates that the given `keys` of the test case with the given `testCaseName` are disjoint from any keys previously
+  /// provided to this method. If a duplicate key is found, the method fatally errs.
+  func validate(keys: Set<String>, ofTestCaseWithName testCaseName: String) {
 
     keys.forEach {
-      self.keys.insert($0)
+      if let previousTestCaseName = self.keysToTestCaseNames[$0] {
+        fatalError("Duplication detected. Key \($0) used both in \(testCaseName) and \(previousTestCaseName)")
+      }
+
+      self.keysToTestCaseNames[$0] = testCaseName
     }
   }
 }

--- a/Tempura/UITests/UITestCaseKeyValidator.swift
+++ b/Tempura/UITests/UITestCaseKeyValidator.swift
@@ -8,6 +8,8 @@
 import Foundation
 
 /// Mutable data structure for ensuring that sets of given keys are disjoint from previously provided keys.
+///
+/// @note Data structure is thread-safe.
 class UITestCaseKeyValidator {
   /// Singleton instance of this class.
   static let singletonInstance = UITestCaseKeyValidator()
@@ -15,12 +17,16 @@ class UITestCaseKeyValidator {
   /// Mapping of keys to test case names with which the `validate` method of this instance has been invoked.
   private var keysToTestCaseNames = [String: String]()
 
+  /// Lock used internally for thread-safety.
+  private let lock = NSRecursiveLock()
+
   /// Initializes a new instance.
   private init() {}
 
   /// Validates that the given `keys` of the test case with the given `testCaseName` are disjoint from any keys previously
   /// provided to this method. If a duplicate key is found, the method fatally errs.
   func validate(keys: Set<String>, ofTestCaseWithName testCaseName: String) {
+    self.lock.lock()
 
     keys.forEach {
       if let previousTestCaseName = self.keysToTestCaseNames[$0] {
@@ -29,5 +35,7 @@ class UITestCaseKeyValidator {
 
       self.keysToTestCaseNames[$0] = testCaseName
     }
+
+    self.lock.unlock()
   }
 }

--- a/Tempura/UITests/ViewControllerTestCase.swift
+++ b/Tempura/UITests/ViewControllerTestCase.swift
@@ -81,7 +81,8 @@ public protocol ViewControllerTestCase {
 
 public extension ViewControllerTestCase where Self: XCTestCase {
   func uiTest(testCases: [String: VC.V.VM], context: UITests.VCContext<VC>) {
-    
+    UITestCaseKeyValidator.singletonInstance.validate(keys: Set(testCases.keys))
+
     let screenSizeDescription: String = "\(UIScreen.main.bounds.size)"
     let descriptions: [String: String] = Dictionary(uniqueKeysWithValues: testCases.keys.map { identifier in
       let description = "\(identifier) \(screenSizeDescription)"

--- a/Tempura/UITests/ViewControllerTestCase.swift
+++ b/Tempura/UITests/ViewControllerTestCase.swift
@@ -38,7 +38,6 @@ public protocol TestableViewController: UIViewController {
   var rootView: V { get }
 }
 
-
 extension ViewController: TestableViewController {}
 
 public protocol ViewControllerTestCase {
@@ -79,7 +78,6 @@ public protocol ViewControllerTestCase {
   /// this is typically used to manually inject the ViewModel to all the children VCs.
   func configure(vc: VC, for testCase: String, model: VC.V.VM)
 }
-
 
 public extension ViewControllerTestCase where Self: XCTestCase {
   func uiTest(testCases: [String: VC.V.VM], context: UITests.VCContext<VC>) {

--- a/Tempura/UITests/ViewControllerTestCase.swift
+++ b/Tempura/UITests/ViewControllerTestCase.swift
@@ -81,7 +81,7 @@ public protocol ViewControllerTestCase {
 
 public extension ViewControllerTestCase where Self: XCTestCase {
   func uiTest(testCases: [String: VC.V.VM], context: UITests.VCContext<VC>) {
-    UITestCaseKeyValidator.singletonInstance.validate(keys: Set(testCases.keys))
+    UITestCaseKeyValidator.singletonInstance.validate(keys: Set(testCases.keys), ofTestCaseWithName: "\(Self.self)")
 
     let screenSizeDescription: String = "\(UIScreen.main.bounds.size)"
     let descriptions: [String: String] = Dictionary(uniqueKeysWithValues: testCases.keys.map { identifier in

--- a/Tempura/UITests/ViewTestCase.swift
+++ b/Tempura/UITests/ViewTestCase.swift
@@ -55,7 +55,6 @@ public protocol ViewTestCase {
   func isViewReady(_ view: V, identifier: String) -> Bool
 }
 
-
 public extension ViewTestCase where Self: XCTestCase {
   func uiTest(testCases: [String: V.VM], context: UITests.Context<V>) {
     let snapshotConfiguration = UITests.ScreenSnapshot<V>(

--- a/Tempura/UITests/ViewTestCase.swift
+++ b/Tempura/UITests/ViewTestCase.swift
@@ -57,6 +57,8 @@ public protocol ViewTestCase {
 
 public extension ViewTestCase where Self: XCTestCase {
   func uiTest(testCases: [String: V.VM], context: UITests.Context<V>) {
+    UITestCaseKeyValidator.singletonInstance.validate(keys: Set(testCases.keys))
+
     let snapshotConfiguration = UITests.ScreenSnapshot<V>(
       type: V.self,
       container: context.container,

--- a/Tempura/UITests/ViewTestCase.swift
+++ b/Tempura/UITests/ViewTestCase.swift
@@ -57,7 +57,7 @@ public protocol ViewTestCase {
 
 public extension ViewTestCase where Self: XCTestCase {
   func uiTest(testCases: [String: V.VM], context: UITests.Context<V>) {
-    UITestCaseKeyValidator.singletonInstance.validate(keys: Set(testCases.keys))
+    UITestCaseKeyValidator.singletonInstance.validate(keys: Set(testCases.keys), ofTestCaseWithName: "\(Self.self)")
 
     let snapshotConfiguration = UITests.ScreenSnapshot<V>(
       type: V.self,


### PR DESCRIPTION
**Why**
Executing the `uiTest` methods with duplicate keys causes previously created images to be overridden. This is usually undesirable and should be prevented programmatically.

**Changes**
A singleton `UITestCaseKeyValidator` instance for validating the uniqueness of UI test keys is introduced and used in the relevant methods.