### PR TITLE
Reference XCake in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,7 +408,10 @@ class ParentViewControllerUITest: XCTestCase, ViewControllerTestCase {
 
 ### Example application
 
-This repository contains a demo of a todo list application done with Tempura. After a `pod install`, open the project and run the `Demo` target.
+This repository contains a demo of a todo list application done with Tempura. To generate an XCode 
+project file you can use [XCake](https://github.com/igor-makarov/xcake). Run `xcake make`, followed
+by a `pod install`, open the project and run the `Demo` target. When doing so, check the `Demo` 
+scheme to make sure `Demo.app` is set as executable.
 
 ### Check out the documentation
 

--- a/README.md
+++ b/README.md
@@ -408,7 +408,7 @@ class ParentViewControllerUITest: XCTestCase, ViewControllerTestCase {
 
 ### Example application
 
-This repository contains a demo of a todo list application done with Tempura. To generate an XCode project file you can use [XCake](https://github.com/igor-makarov/xcake). Run `xcake make`, followed by a `pod install`, open the project and run the `Demo` target. When doing so, check the `Demo` scheme to make sure `Demo.app` is set as executable.
+This repository contains a demo of a todo list application done with Tempura. To generate an Xcode project file you can use [Xcake](https://github.com/igor-makarov/xcake). Run `xcake make`, followed by a `pod install`, open the project and run the `Demo` target. When doing so, check the `Demo` scheme to make sure `Demo.app` is set as executable.
 
 ### Check out the documentation
 

--- a/README.md
+++ b/README.md
@@ -408,10 +408,7 @@ class ParentViewControllerUITest: XCTestCase, ViewControllerTestCase {
 
 ### Example application
 
-This repository contains a demo of a todo list application done with Tempura. To generate an XCode 
-project file you can use [XCake](https://github.com/igor-makarov/xcake). Run `xcake make`, followed
-by a `pod install`, open the project and run the `Demo` target. When doing so, check the `Demo` 
-scheme to make sure `Demo.app` is set as executable.
+This repository contains a demo of a todo list application done with Tempura. To generate an XCode project file you can use [XCake](https://github.com/igor-makarov/xcake). Run `xcake make`, followed by a `pod install`, open the project and run the `Demo` target. When doing so, check the `Demo` scheme to make sure `Demo.app` is set as executable.
 
 ### Check out the documentation
 


### PR DESCRIPTION
**Why**
The purpose of this PR is updating the `README.md` to elicit the need to use [XCake](https://github.com/igor-makarov/xcake) to generate a project file a run the `Demo` app.

**Changes**
No code changes, just the `README.md` is impacted.
