### PR TITLE
[Feat] Add Hydra 2.0.6 as explicit dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## unreleased
+
+- Add Hydra (`>= 2.0.6`) as an explicit dependency. [#113](https://github.com/BendingSpoons/tempura-swift/pull/113)
+
 ## Tempura 6.2.0
 
 - Add validation of UITests keys uniqueness [#103](https://github.com/BendingSpoons/tempura-swift/pull/103)

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
   - DeepDiff (2.3.1)
-  - HydraAsync (2.0.5)
-  - Katana (5.0.0):
+  - HydraAsync (2.0.6)
+  - Katana (5.1.1):
     - HydraAsync (< 3, >= 2.0.5)
   - Nimble (7.3.4)
   - PinLayout (1.9.2)
@@ -11,6 +11,7 @@ PODS:
 
 DEPENDENCIES:
   - DeepDiff (~> 2.0)
+  - HydraAsync (< 3, >= 2.0.6)
   - Katana (< 6, >= 5.0)
   - Nimble (~> 7.3)
   - PinLayout
@@ -29,8 +30,8 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   DeepDiff: e5ae6c50d0321568e4508cec5930b9f10bb293fc
-  HydraAsync: 6b74390f143e7edfb8bd3c706262b67bbefc09df
-  Katana: 3a49ea78f34f79f9787722b290bd4131030044fa
+  HydraAsync: 8d589bd725b0224f899afafc9a396327405f8063
+  Katana: c39f776bca8a525b74840a6b3dae604cfcc31fff
   Nimble: 051e3d8912d40138fa5591c78594f95fb172af37
   PinLayout: 0d96022e46e8b80468d819f182a393b97ca038da
   Quick: f4f7f063c524394c73ed93ac70983c609805d481
@@ -38,4 +39,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: c660f753d69f3341bba393383f11c640fa1f0ad1
 
-COCOAPODS: 1.10.0
+COCOAPODS: 1.10.1

--- a/Tempura.podspec
+++ b/Tempura.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '11.0'
   s.swift_version = '5.0'
 
-  s.dependency 'Hydra', '>= 2.0.6', '< 3'
+  s.dependency 'HydraAsync', '>= 2.0.6', '< 3'
   s.dependency 'Katana', '>= 5.0', '< 6'
 
   s.ios.source_files = [

--- a/Tempura.podspec
+++ b/Tempura.podspec
@@ -9,8 +9,10 @@ Pod::Spec.new do |s|
   s.source           = { :git => 'https://github.com/BendingSpoons/tempura-swift.git', :tag => s.version.to_s }
 
   s.ios.deployment_target = '11.0'
-  s.dependency 'Katana', '>= 5.0', '< 6'
   s.swift_version = '5.0'
+
+  s.dependency 'Hydra', '>= 2.0.6', '< 3'
+  s.dependency 'Katana', '>= 5.0', '< 6'
 
   s.ios.source_files = [
     'Tempura/Core/**/*.swift',

--- a/Tempura/Navigation/NavigationActions.swift
+++ b/Tempura/Navigation/NavigationActions.swift
@@ -33,7 +33,7 @@ public struct Navigate: NavigationSideEffect {
   /// to know what a `SideEffect` is.
   public func anySideEffect(_ context: AnySideEffectContext) throws -> Any {
     guard let dependencies = context.anyDependencies as? NavigationProvider else { fatalError("DependenciesContainer must conform to `NavigationProvider`") }
-    try await(dependencies.navigator.changeRoute(newRoute: self.route, animated: self.animated, context: self.context))
+    try Hydra.await(dependencies.navigator.changeRoute(newRoute: self.route, animated: self.animated, context: self.context))
     return ()
   }
 }
@@ -88,7 +88,7 @@ public struct Show: NavigationSideEffect {
   /// to know what a `SideEffect` is.
   public func anySideEffect(_ context: AnySideEffectContext) throws -> Any {
     guard let dependencies = context.anyDependencies as? NavigationProvider else { fatalError("DependenciesContainer must conform to `NavigationProvider`") }
-    try await(dependencies.navigator.show(self.identifiersToShow, animated: self.animated, context: self.context))
+    try Hydra.await(dependencies.navigator.show(self.identifiersToShow, animated: self.animated, context: self.context))
     return ()
   }
 }
@@ -156,7 +156,7 @@ public struct Hide: NavigationSideEffect {
   /// to know what a `SideEffect` is.
   public func anySideEffect(_ context: AnySideEffectContext) throws -> Any {
     guard let dependencies = context.anyDependencies as? NavigationProvider else { fatalError("DependenciesContainer must conform to `NavigationProvider`") }
-    try await(dependencies.navigator.hide(self.identifierToHide, animated: self.animated, context: self.context, atomic: self.atomic))
+    try Hydra.await(dependencies.navigator.hide(self.identifierToHide, animated: self.animated, context: self.context, atomic: self.atomic))
     return ()
   }
 }
@@ -172,7 +172,7 @@ extension AnyStore {
 
   @available(*, deprecated)
   public func awaitDispatch<RSE: NavigationSideEffect>(_ dispatchable: RSE) throws {
-    return try await(self.dispatch(dispatchable))
+    return try Hydra.await(self.dispatch(dispatchable))
   }
 }
 
@@ -185,7 +185,7 @@ extension AnySideEffectContext {
 
   @available(*, deprecated)
   public func awaitDispatch<RSE: NavigationSideEffect>(ramen dispatchable: RSE) throws {
-    return try await(self.dispatch(dispatchable))
+    return try Hydra.await(self.dispatch(dispatchable))
   }
 }
 
@@ -197,7 +197,7 @@ extension ViewController {
 
   @available(*, deprecated)
   public func __unsafeAwaitDispatch<RSE: NavigationSideEffect>(_ dispatchable: RSE) throws {
-    return try await(self.store.dispatch(dispatchable))
+    return try Hydra.await(self.store.dispatch(dispatchable))
   }
 }
 


### PR DESCRIPTION
Based on #111 

**Why**
This ensures that:
- Tempura uses a version of Hydra compatible with Swift 5.5+.
- Tempura considers Hydra as an explicit dependency.

**Changes**
No API change

**Tasks**
* [x] Add relevant tests, if needed
* [x] Add documentation, if needed
* [x] Update README, if needed
* [x] Ensure that the demo project works properly