### PR TITLE
[Feat] Remove deprecated APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
 # Changelog
 
-## unreleased
+## TempuraTesting unreleased
 
-- Add Hydra (`>= 2.0.6`) as an explicit dependency. [#113](https://github.com/BendingSpoons/tempura-swift/pull/113)
+- Removed deprecated global `test` functions. The `ViewTestCase` API should be used instead. [#114](https://github.com/BendingSpoons/tempura-swift/pull/114)
+
+## Tempura unreleased
+
+- Removed `UITestCase` typealias. `ViewTestCase` should be used instead. No other changes should be necessary. [#114](https://github.com/BendingSpoons/tempura-swift/pull/114)
+- Removed deprecated `dispatch` and `unsafeDispatch` for `NavigationSideEffect` on `AnyStore` and `AnySideEffectContext`. Katana's normal dispatch accepting `Dispatchable`s should be used instead. [#114](https://github.com/BendingSpoons/tempura-swift/pull/114)
+- Removed `__unsafeDispatch` and `__unsafeAwaitDispatch` for `NavigationSideEffect` on `ViewController`. The base methods accepting `Dispatchable`s should be used instead. [#114](https://github.com/BendingSpoons/tempura-swift/pull/114)
+- Added Hydra (`>= 2.0.6`) as an explicit dependency. [#113](https://github.com/BendingSpoons/tempura-swift/pull/113)
 
 ## Tempura 6.2.0
 

--- a/Tempura/Navigation/NavigationActions.swift
+++ b/Tempura/Navigation/NavigationActions.swift
@@ -161,46 +161,6 @@ public struct Hide: NavigationSideEffect {
   }
 }
 
-// MARK: - Katana Helpers
-
-extension AnyStore {
-  @available(*, deprecated, message: "Deprecated in favor of Katana's dispatch")
-  @discardableResult
-  public func dispatch<RSE: NavigationSideEffect>(_ dispatchable: RSE) -> Promise<Void> {
-    return self.anyDispatch(dispatchable).void
-  }
-
-  @available(*, deprecated)
-  public func awaitDispatch<RSE: NavigationSideEffect>(_ dispatchable: RSE) throws {
-    return try Hydra.await(self.dispatch(dispatchable))
-  }
-}
-
-extension AnySideEffectContext {
-  @available(*, deprecated, message: "Deprecated in favor of Katana's dispatch")
-  @discardableResult
-  public func dispatch<RSE: NavigationSideEffect>(_ dispatchable: RSE) -> Promise<Void> {
-    return self.anyDispatch(dispatchable).void
-  }
-
-  @available(*, deprecated)
-  public func awaitDispatch<RSE: NavigationSideEffect>(ramen dispatchable: RSE) throws {
-    return try Hydra.await(self.dispatch(dispatchable))
-  }
-}
-
-extension ViewController {
-  @discardableResult
-  public func __unsafeDispatch<RSE: NavigationSideEffect>(_ dispatchable: RSE) -> Promise<Void> {
-    return self.store.dispatch(dispatchable)
-  }
-
-  @available(*, deprecated)
-  public func __unsafeAwaitDispatch<RSE: NavigationSideEffect>(_ dispatchable: RSE) throws {
-    return try Hydra.await(self.store.dispatch(dispatchable))
-  }
-}
-
 /// Implementation of the `CustomDebugStringConvertible` protocol
 extension Hide: CustomDebugStringConvertible {
   public var debugDescription: String {

--- a/Tempura/UITests/UITests.swift
+++ b/Tempura/UITests/UITests.swift
@@ -331,41 +331,6 @@ public enum UITests {
   }
 }
 
-/// Test a ViewControllerModellableView embedded in a Container with a specific ViewModel.
-/// The test will produce a screenshot of the view.
-/// The screenshots will be located in the directory specified inside the plist with the `UI_TEST_DIR` key.
-/// After the screenshot is completed, the test will pass.
-/// This function can only be used in a XCTest environment.
-@available(*, deprecated, message: "Use UITestCase API instead")
-public func test<V: ViewControllerModellableView & UIView>(_ viewType: V.Type,
-                                                           with model: V.VM,
-                                                           identifier: String,
-                                                           container: UITests.Container = .none,
-                                                           hooks: [UITests.Hook: UITests.HookClosure<V>] = [:],
-                                                           size: CGSize = UIScreen.main.bounds.size) {
-  test(viewType, with: [identifier: model], container: container, hooks: hooks, size: size)
-}
-
-/// Test a ViewControllerModellableView embedded in a Container with a specific set of ViewModels.
-/// The test will produce a set of screenshots of the view, one for each ViewModel specified.
-/// The screenshots will be located in the directory specified inside the plist with the `UI_TEST_DIR` key.
-/// After the screenshot is completed, the test will pass.
-/// This function can only be used in a XCTest environment.
-@available(*, deprecated, message: "Use UITestCase API instead")
-public func test<V: ViewControllerModellableView & UIView>(_ viewType: V.Type,
-                                                           with models: [String: V.VM],
-                                                           container: UITests.Container = .none,
-                                                           hooks: [UITests.Hook: UITests.HookClosure<V>] = [:],
-                                                           size: CGSize = UIScreen.main.bounds.size) {
-  let snapshotConfiguration = UITests.ScreenSnapshot<V>(type: viewType, container: container, models: models, hooks: hooks, size: size)
-  let viewControllers = snapshotConfiguration.renderingViewControllers
-  let screenSizeDescription: String = "\(UIScreen.main.bounds.size.description)"
-  for (identifier, vcs) in viewControllers {
-    let description = "\(identifier) \(screenSizeDescription)"
-    UITests.verifyView(view: vcs.container.view, description: description)
-  }
-}
-
 extension CGSize {
   public var description: String {
     return "\(Int(self.width))x\(Int(self.height))"

--- a/Tempura/UITests/ViewTestCase.swift
+++ b/Tempura/UITests/ViewTestCase.swift
@@ -22,10 +22,6 @@ import Tempura
  
  Note that this is a protocol as Xcode fails to recognize methods of XCTestCase's subclasses that are written in Swift.
  */
-
-@available(*, deprecated, message: "`UITestCase` has been renamed to `ViewTestCase`")
-typealias UITestCase = ViewTestCase
-
 public protocol ViewTestCase {
   associatedtype V: UIView & ViewControllerModellableView
 


### PR DESCRIPTION
**Why**
Based on #113 

**Changes**

#### TempuraTesting

- Removed deprecated global `test` functions. The `ViewTestCase` API should be used instead.
- Removed `UITestCase` typealias. `ViewTestCase` should be used instead. No other changes should be necessary.

#### Tempura unreleased

- Removed deprecated `dispatch` and `unsafeDispatch` for `NavigationSideEffect` on `AnyStore` and `AnySideEffectContext`. Katana's normal dispatch accepting `Dispatchable`s should be used instead.
- Removed `__unsafeDispatch` and `__unsafeAwaitDispatch` for `NavigationSideEffect` on `ViewController`. The base methods accepting `Dispatchable`s should be used instead.

**Tasks**
* [x] Add relevant tests, if needed
* [x] Add documentation, if needed
* [x] Update README, if needed
* [x] Ensure that the demo project works properly