### PR TITLE
[Feat] Witness navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Tempura 7.1.0
+
+- Allow to init Navigation with custom `RoutableProvider`. [#125](https://github.com/BendingSpoons/tempura-swift/pull/125)
+
 ## Tempura 7.0.1
 
 - Fix possible initialization of the ViewModel with an older state.

--- a/Tempura/Sources/Navigation/Navigator.swift
+++ b/Tempura/Sources/Navigation/Navigator.swift
@@ -178,10 +178,16 @@ public class Navigator {
   private let routingQueue = DispatchQueue(label: "routing queue")
   private var rootInstaller: RootInstaller! // swiftlint:disable:this implicitly_unwrapped_optional
   private var window: UIWindow! // swiftlint:disable:this implicitly_unwrapped_optional
-  private var routableProvider: RoutableProvider! // swiftlint:disable:this implicitly_unwrapped_optional
+  private let routableProvider: RoutableProvider // swiftlint:disable:this implicitly_unwrapped_optional
 
   /// Initializes and return a Navigator.
-  public init() {}
+  ///
+  /// - parameter routableProvider: The provider of the routables in the navigation hierarchy. The  default value uses the
+  ///                               UIApplication to check the visible view controllers that conform to the RouteInspectable
+  ///                               protocol. Check also `currentViewControllers` helper documentation.
+  public init(routableProvider: RoutableProvider = .live(using: .shared)) {
+    self.routableProvider = routableProvider
+  }
   /// Start the navigator.
   ///
   /// In order to use the navigation system, you need to start the navigator
@@ -212,13 +218,11 @@ public class Navigator {
   public func start(
     using rootInstaller: RootInstaller,
     in window: UIWindow,
-    at rootElementIdentifier: RouteElementIdentifier,
-    routableProvider: RoutableProvider = .live(using: .shared)
+    at rootElementIdentifier: RouteElementIdentifier
   ) {
     self.rootInstaller = rootInstaller
     self.window = window
     self.install(identifier: rootElementIdentifier, context: nil)
-    self.routableProvider = routableProvider
   }
 
   /// Generic version of the same method.

--- a/Tempura/Sources/Navigation/Navigator.swift
+++ b/Tempura/Sources/Navigation/Navigator.swift
@@ -178,6 +178,7 @@ public class Navigator {
   private let routingQueue = DispatchQueue(label: "routing queue")
   private var rootInstaller: RootInstaller! // swiftlint:disable:this implicitly_unwrapped_optional
   private var window: UIWindow! // swiftlint:disable:this implicitly_unwrapped_optional
+  private var RoutableProvider: RoutableProvider! // swiftlint:disable:this implicitly_unwrapped_optional
 
   /// Initializes and return a Navigator.
   public init() {}
@@ -211,11 +212,13 @@ public class Navigator {
   public func start(
     using rootInstaller: RootInstaller,
     in window: UIWindow,
-    at rootElementIdentifier: RouteElementIdentifier
+    at rootElementIdentifier: RouteElementIdentifier,
+    applicationWitness: RoutableProvider = .live(using: .shared)
   ) {
     self.rootInstaller = rootInstaller
     self.window = window
     self.install(identifier: rootElementIdentifier, context: nil)
+    self.RoutableProvider = applicationWitness
   }
 
   /// Generic version of the same method.
@@ -235,7 +238,7 @@ public class Navigator {
 
   func changeRoute(newRoute: Route, animated: Bool, context: Any?) -> Promise<Void> {
     let promise = Promise<Void>(in: .background) { resolve, _, _ in
-      let oldRoutables = UIApplication.shared.currentRoutables
+      let oldRoutables = self.RoutableProvider.currentRoutable()
       let routeChanges = Navigator.routingChanges(from: oldRoutables, new: newRoute)
 
       self.routeDidChange(changes: routeChanges, isAnimated: animated, context: context) {
@@ -248,7 +251,7 @@ public class Navigator {
   @discardableResult
   func show(_ elementsToShow: [RouteElementIdentifier], animated: Bool, context: Any?) -> Promise<Void> {
     let promise = Promise<Void>(in: .background) { resolve, _, _ in
-      let oldRoutables = UIApplication.shared.currentRoutables
+      let oldRoutables = self.RoutableProvider.currentRoutable()
       let oldRoute = oldRoutables.map { $0.routeIdentifier }
       let newRoute: Route = oldRoute + elementsToShow
       let routeChanges = Navigator.routingChanges(from: oldRoutables, new: newRoute)
@@ -263,7 +266,7 @@ public class Navigator {
   @discardableResult
   func hide(_ elementToHide: RouteElementIdentifier, animated: Bool, context: Any?, atomic: Bool = false) -> Promise<Void> {
     let promise = Promise<Void>(in: .background) { resolve, _, _ in
-      let oldRoutables = UIApplication.shared.currentRoutables
+      let oldRoutables = self.RoutableProvider.currentRoutable()
       let oldRoute = oldRoutables.map { $0.routeIdentifier }
 
       guard let start = oldRoute.indices.reversed().first(where: { oldRoute[$0] == elementToHide }) else {
@@ -361,7 +364,7 @@ public class Navigator {
         switch routeChange {
         case .hide(let toHide):
           DispatchQueue.main.async {
-            let routables = UIApplication.shared.currentRoutables
+            let routables = self.RoutableProvider.currentRoutable()
 
             guard let indexToHide = routables.firstIndex(where: {
               $0 === toHide
@@ -395,7 +398,7 @@ public class Navigator {
 
         case .show(let toShow):
           DispatchQueue.main.async {
-            let routables = UIApplication.shared.currentRoutables
+            let routables = self.RoutableProvider.currentRoutable()
             let askTo = routables.reversed()
 
             let from = routables.last!.routeIdentifier // swiftlint:disable:this force_unwrapping
@@ -595,5 +598,25 @@ extension UITabBarController: CustomRouteInspectables {
 extension UIViewController: RouteInspectable {
   public var nextRouteController: UIViewController? {
     return self.presentedViewController
+  }
+}
+
+public struct RoutableProvider {
+  public let currentRoutable: () -> [Routable]
+
+  /// Memberwise
+  public init(
+    currentRoutable: @escaping () -> [Routable]
+  ) {
+    self.currentRoutable = currentRoutable
+  }
+}
+
+extension RoutableProvider {
+  /// The live version of the witness
+  public static func live(using application: UIApplication) -> Self {
+    return .init(
+      currentRoutable: { application.currentRoutables }
+    )
   }
 }

--- a/Tempura/Sources/Navigation/Navigator.swift
+++ b/Tempura/Sources/Navigation/Navigator.swift
@@ -178,7 +178,7 @@ public class Navigator {
   private let routingQueue = DispatchQueue(label: "routing queue")
   private var rootInstaller: RootInstaller! // swiftlint:disable:this implicitly_unwrapped_optional
   private var window: UIWindow! // swiftlint:disable:this implicitly_unwrapped_optional
-  private let routableProvider: RoutableProvider // swiftlint:disable:this implicitly_unwrapped_optional
+  private let routableProvider: RoutableProvider
 
   /// Initializes and return a Navigator.
   ///


### PR DESCRIPTION
**Why**
This PR allows the enriching of the `Navigation` object with a `RoutableProvider` to allow Tempura to handle its navigation without being the only manager of the app's navigation. 
This is needed when Tempura is added on top of another architecture that already has control of the navigation.

**Changes**
Enrich init of `Navigation` object with a `RoutableProvider` inited with a default value that is the live implementation.

**Tasks**
* [x] Add relevant tests, if needed
* [x] Add documentation, if needed
* [x] Update README, if needed
* [x] Ensure that the demo project works properly