### PR TITLE
Expose the route from the Navigator

### DIFF
--- a/Tempura/Sources/Navigation/Navigator.swift
+++ b/Tempura/Sources/Navigation/Navigator.swift
@@ -180,6 +180,11 @@ public class Navigator {
   private var window: UIWindow! // swiftlint:disable:this implicitly_unwrapped_optional
   private let routableProvider: RoutableProvider
 
+  /// The indentifiers of the routables in the visible hierarchy.
+  public var currentRoutableIdentifiers: Route {
+    self.routableProvider.currentRoutable().map(\.routeIdentifier)
+  }
+
   /// Initializes and return a Navigator.
   ///
   /// - parameter routableProvider: The provider of the routables in the navigation hierarchy. The  default value uses the


### PR DESCRIPTION
**Why**
Some App-specific logic relies on the current Route, a common example is to use something like this:
```swift
if currentRoutableIdentifiers.contains(Screen.X) { ... } 
```

**Changes**
Let the navigator expose the route.

**Tasks**
* [ ] Add relevant tests, if needed
* [x] Add documentation, if needed
* [ ] Update README, if needed
* [ ] Ensure that the demo project works properly